### PR TITLE
Defer ip address resolving

### DIFF
--- a/Source/Daemon/Communication/DaemonClient.cpp
+++ b/Source/Daemon/Communication/DaemonClient.cpp
@@ -8,6 +8,8 @@
 #include "spdlog/spdlog.h"
 
 #include "Messages.hpp"
+#include "Data/ResolveData.hpp"
+#include "Net/Resolver.hpp"
 #include "Rules/RuleManager.hpp"
 
 void WDaemonClient::OnDataReceived(WBuffer& RecvBuf)
@@ -26,7 +28,37 @@ void WDaemonClient::OnDataReceived(WBuffer& RecvBuf)
 		case MT_RuleUpdate:
 			WRuleManager::GetInstance().HandleRuleChange(RecvBuf);
 			break;
+		case MT_ResolveRequest:
+			HandleResolveRequest(RecvBuf);
+			break;
 		default:
 			break;
 	}
+}
+
+void WDaemonClient::HandleResolveRequest(WBuffer const& Buf)
+{
+	WResolveRequest   Request{};
+	std::stringstream ss;
+	ss.write(Buf.GetData(), static_cast<long int>(Buf.GetWritePos()));
+	try
+	{
+		{
+			ss.seekg(1); // Skip message type
+			cereal::BinaryInputArchive iar(ss);
+			iar(Request);
+		}
+	}
+	catch (std::exception const& e)
+	{
+		spdlog::error("Failed to deserialize resolve request: {}", e.what());
+		return;
+	}
+
+	WResolver::GetInstance().Resolve(Request.AddressToResolve).Then([Request, this](std::string const& Hostname) {
+		WResolveResponse Response{};
+		Response.AddressToResolve = Request.AddressToResolve;
+		Response.ResolveResult = Hostname;
+		SendMessage(MT_ResolveResponse, Response);
+	});
 }

--- a/Source/Daemon/Communication/DaemonClient.cpp
+++ b/Source/Daemon/Communication/DaemonClient.cpp
@@ -54,11 +54,20 @@ void WDaemonClient::HandleResolveRequest(WBuffer const& Buf)
 		spdlog::error("Failed to deserialize resolve request: {}", e.what());
 		return;
 	}
-
-	WResolver::GetInstance().Resolve(Request.AddressToResolve).Then([Request, this](std::string const& Hostname) {
-		WResolveResponse Response{};
-		Response.AddressToResolve = Request.AddressToResolve;
-		Response.ResolveResult = Hostname;
-		SendMessage(MT_ResolveResponse, Response);
-	});
+	WResolver::GetInstance()
+		.Resolve(Request.AddressToResolve)
+		.Then([Request, Socket = ClientSocket](std::string const& Hostname) {
+			if (!Socket->IsConnected())
+			{
+				spdlog::warn("Client disconnected before resolve response could be sent for {}",
+					Request.AddressToResolve.ToString());
+				return;
+			}
+			spdlog::debug(
+				"Finished resolve request for address: {} -> {}", Request.AddressToResolve.ToString(), Hostname);
+			WResolveResponse Response{};
+			Response.AddressToResolve = Request.AddressToResolve;
+			Response.ResolveResult = Hostname;
+			Socket->SendFramed(WDaemonClient::MakeMessage(MT_ResolveResponse, Response));
+		});
 }

--- a/Source/Daemon/Communication/DaemonClient.hpp
+++ b/Source/Daemon/Communication/DaemonClient.hpp
@@ -34,12 +34,14 @@ class WDaemonClient
 
 	WProcessId ClientPid{ 0 };
 
-	static void OnDataReceived(WBuffer& RecvBuf);
+	void OnDataReceived(WBuffer& RecvBuf);
+
+	void HandleResolveRequest(WBuffer const& Buf);
 
 public:
 	explicit WDaemonClient(std::shared_ptr<IClientSocket> CS) : ClientSocket(std::move(CS))
 	{
-		ClientSocket->GetDataSignal().connect([](WBuffer& Buffer) { OnDataReceived(Buffer); });
+		ClientSocket->GetDataSignal().connect([this](WBuffer& Buffer) { OnDataReceived(Buffer); });
 		ClientSocket->GetClosedSignal().connect([] { spdlog::info("Client disconnected"); });
 		ClientSocket->StartListenThread();
 	}

--- a/Source/Daemon/Communication/DaemonSocket.cpp
+++ b/Source/Daemon/Communication/DaemonSocket.cpp
@@ -45,10 +45,6 @@ static void SendInitialDataToClient(std::shared_ptr<WDaemonClient> const& Client
 		Client->SendMessage(MT_TrafficTree, *SystemMap.GetSystemItem());
 		Client->SendMessage(MT_ConnectionHistory, WConnectionHistory::GetInstance().Serialize());
 	}
-	{
-		std::lock_guard Lock(WResolver::GetInstance().ResolvedAddressesMutex);
-		Client->SendMessage(MT_ResolvedAddresses, WResolver::GetInstance().GetResolvedAddresses());
-	}
 
 	Client->SendMessage(MT_MemoryStats, WMemoryUsage::GetMemoryStats());
 

--- a/Source/Daemon/Data/MapUpdate.cpp
+++ b/Source/Daemon/Data/MapUpdate.cpp
@@ -110,11 +110,6 @@ WTrafficTreeUpdates const& WMapUpdate::GetUpdates()
 		Addition.ApplicationPath = PATI->ApplicationPath;
 		Addition.ApplicationName = PATI->ApplicationName;
 		Addition.ApplicationCommandLine = PATI->ApplicationCommandLine;
-		{
-			ZoneScopedN("ResolveAddress");
-			Addition.ResolvedAddress =
-				WResolver::GetInstance().Resolve(Socket->TrafficItem->SocketTuple.RemoteEndpoint.Address);
-		}
 		Addition.SocketTuple = Socket->TrafficItem->SocketTuple;
 		Addition.ConnectionState = Socket->TrafficItem->ConnectionState;
 		Addition.SocketType = Socket->TrafficItem->SocketType;
@@ -134,10 +129,6 @@ WTrafficTreeUpdates const& WMapUpdate::GetUpdates()
 		Addition.ItemId = TupleCounter.second->TrafficItem->ItemId;
 		Addition.SocketItemId = TupleCounter.second->ParentSocket->TrafficItem->ItemId;
 		Addition.Endpoint = TupleCounter.first;
-		{
-			ZoneScopedN("ResolveAddress");
-			Addition.ResolvedAddress = WResolver::GetInstance().Resolve(Addition.Endpoint.Address);
-		}
 	}
 
 	Clear();

--- a/Source/Daemon/Net/Resolver.cpp
+++ b/Source/Daemon/Net/Resolver.cpp
@@ -12,10 +12,12 @@
 #include "tracy/Tracy.hpp"
 #include "spdlog/spdlog.h"
 
-void WResolver::ResolveAddress(WIPAddress const& Address)
+void WResolver::ResolveAddress(WQueuedRequest const& Request)
 {
 	int  Result = 0;
 	char Host[NI_MAXHOST]{};
+
+	auto const& Address = Request.AddressToResolve;
 
 	if (Address.Family == EIPFamily::IPv6)
 	{
@@ -92,15 +94,18 @@ void WResolver::ResolveAddress(WIPAddress const& Address)
 	if (Host == Address.ToString())
 	{
 		ResolvedAddresses[Address] = {};
+		Request.Promise.Finish({});
 		return;
 	}
 
 	spdlog::debug("Resolved {} to {}", Address.ToString(), Host);
 	ResolvedAddresses[Address] = Host;
+	Request.Promise.Finish(Host);
 }
 
 void WResolver::ResolverThreadFunc()
 {
+	static std::string Empty = {};
 	tracy::SetThreadName("ResolverThread");
 	while (bRunning)
 	{
@@ -114,11 +119,22 @@ void WResolver::ResolverThreadFunc()
 
 		if (!PendingAddresses.empty())
 		{
-			WIPAddress Address = PendingAddresses.front();
+			auto const& Request = PendingAddresses.front();
 			PendingAddresses.pop();
-			Lock.unlock();
 
-			ResolveAddress(Address);
+			if (Request.AddressToResolve.IsZero())
+			{
+				Request.Promise.Finish(Empty);
+			}
+			else if (auto It = ResolvedAddresses.find(Request.AddressToResolve); It != ResolvedAddresses.end())
+			{
+				Request.Promise.Finish(It->second);
+			}
+			else
+			{
+				Lock.unlock();
+				ResolveAddress(Request);
+			}
 		}
 	}
 }
@@ -139,30 +155,17 @@ void WResolver::Stop()
 	}
 }
 
-std::string const& WResolver::Resolve(WIPAddress const& Address)
+TPromise<std::string const&> WResolver::Resolve(WIPAddress const& Address)
 {
-	static std::string Empty = {};
-	if (Address.IsZero())
-	{
-		return Empty;
-	}
-	{
-		std::lock_guard Lock(ResolvedAddressesMutex);
-
-		if (auto It = ResolvedAddresses.find(Address); It != ResolvedAddresses.end())
-		{
-			return It->second;
-		}
-		ResolvedAddresses[Address] = Empty;
-	}
+	TPromise<std::string const&> Promise{};
 
 	{
-		std::lock_guard QueueLock(QueueMutex);
-		PendingAddresses.push(Address);
-		QueueCondition.notify_one();
+		WQueuedRequest  Request{ Address, Promise };
+		std::lock_guard Lock(QueueMutex);
+		PendingAddresses.push(Request);
 	}
 
-	return Empty;
+	return Promise;
 }
 
 WMemoryStat WResolver::GetMemoryUsage()

--- a/Source/Daemon/Net/Resolver.cpp
+++ b/Source/Daemon/Net/Resolver.cpp
@@ -119,7 +119,7 @@ void WResolver::ResolverThreadFunc()
 
 		if (!PendingAddresses.empty())
 		{
-			auto const& Request = PendingAddresses.front();
+			auto Request = PendingAddresses.front(); // copy before pop to keep TPromise's WSharedState alive
 			PendingAddresses.pop();
 
 			if (Request.AddressToResolve.IsZero())
@@ -163,6 +163,7 @@ TPromise<std::string const&> WResolver::Resolve(WIPAddress const& Address)
 		WQueuedRequest  Request{ Address, Promise };
 		std::lock_guard Lock(QueueMutex);
 		PendingAddresses.push(Request);
+		QueueCondition.notify_one();
 	}
 
 	return Promise;

--- a/Source/Daemon/Net/Resolver.hpp
+++ b/Source/Daemon/Net/Resolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Alex <uni@vrsal.cc>
+ * Copyright (c) 2025-2026, Alex <uni@vrsal.cc>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
@@ -16,10 +16,17 @@
 #include "IPAddress.hpp"
 #include "Singleton.hpp"
 #include "Types.hpp"
+#include "Promise.hpp"
 
 class WResolver : public TSingleton<WResolver>, public IMemoryTrackable
 {
-	static constexpr WBytes                     MaxCacheRamUsage = 5 WMiB;
+	struct WQueuedRequest
+	{
+		WIPAddress                   AddressToResolve;
+		TPromise<std::string const&> Promise;
+	};
+
+	static constexpr WBytes                     MaxCacheRamUsage = 1 WMiB;
 	std::unordered_map<WIPAddress, std::string> ResolvedAddresses{};
 
 	std::thread             ResolverThread;
@@ -27,9 +34,9 @@ class WResolver : public TSingleton<WResolver>, public IMemoryTrackable
 	std::mutex              QueueMutex;
 	std::condition_variable QueueCondition;
 	WBytes                  CurrentCacheRamUsage{ 0 };
-	std::queue<WIPAddress>  PendingAddresses;
+	std::queue<WQueuedRequest> PendingAddresses;
 
-	void ResolveAddress(WIPAddress const& ip);
+	void ResolveAddress(WQueuedRequest const& Reuqest);
 
 	void ResolverThreadFunc();
 
@@ -37,7 +44,7 @@ public:
 	void Start();
 	void Stop();
 
-	std::string const& Resolve(WIPAddress const& Address);
+	TPromise<std::string const&> Resolve(WIPAddress const& Address);
 
 	std::mutex                                  ResolvedAddressesMutex;
 	std::unordered_map<WIPAddress, std::string> GetResolvedAddresses() const { return ResolvedAddresses; }

--- a/Source/Gui/Client.cpp
+++ b/Source/Gui/Client.cpp
@@ -51,8 +51,8 @@ void WClient::OnDataReceived(WBuffer& Buf)
 		case MT_AppIconAtlasData:
 			WAppIconAtlas::GetInstance().FromAtlasData(Buf);
 			break;
-		case MT_ResolvedAddresses:
-			TrafficTree->SetResolvedAddresses(Buf);
+		case MT_ResolveResponse:
+			TrafficTree->HandleResolveResponse(Buf);
 			break;
 		case MT_ConnectionHistory:
 			WMainWindow::Get().GetConnectionHistoryWindow().Initialize(Buf);

--- a/Source/Gui/Client.hpp
+++ b/Source/Gui/Client.hpp
@@ -90,7 +90,7 @@ public:
 	}
 
 	template <class T>
-	static bool ReadMessage(WBuffer& Buffer, T& OutData)
+	static bool ReadMessage(WBuffer const& Buffer, T& OutData)
 	{
 		std::stringstream ss;
 		ss.write(Buffer.GetData(), static_cast<long int>(Buffer.GetWritePos()));

--- a/Source/Gui/Windows/DetailsWindow.cpp
+++ b/Source/Gui/Windows/DetailsWindow.cpp
@@ -184,14 +184,9 @@ void WDetailsWindow::DrawSocketDetails() const
 				const_cast<char*>(Sock->SocketTuple.RemoteEndpoint.ToString().c_str()), 64,
 				ImGuiInputTextFlags_ReadOnly);
 		}
-		if (auto It = Tree->GetResolvedAddresses().find(Sock->SocketTuple.RemoteEndpoint.Address);
-			It != Tree->GetResolvedAddresses().end())
+		if (auto Addr = Tree->ResolveAddress(Sock->SocketTuple.RemoteEndpoint.Address); !Addr.empty())
 		{
-			if (!It->second.empty())
-			{
-				ImGui::InputText(
-					TR("hostname"), const_cast<char*>(It->second.c_str()), 128, ImGuiInputTextFlags_ReadOnly);
-			}
+			ImGui::InputText(TR("hostname"), const_cast<char*>(Addr.c_str()), 128, ImGuiInputTextFlags_ReadOnly);
 		}
 		ImGui::Text("%s: %s", TR("__protocol"), ProtocolToString(Sock->SocketTuple.Protocol));
 #if !defined(__EMSCRIPTEN__)
@@ -223,12 +218,9 @@ void WDetailsWindow::DrawTupleDetails() const
 		ImGui::InputText(
 			TR("remote_endpoint"), const_cast<char*>(Ep.ToString().c_str()), 64, ImGuiInputTextFlags_ReadOnly);
 	}
-	if (auto It = Tree->GetResolvedAddresses().find(Ep.Address); It != Tree->GetResolvedAddresses().end())
+	if (auto Addr = Tree->ResolveAddress(Ep.Address); !Addr.empty())
 	{
-		if (!It->second.empty())
-		{
-			ImGui::InputText(TR("hostname"), const_cast<char*>(It->second.c_str()), 128, ImGuiInputTextFlags_ReadOnly);
-		}
+		ImGui::InputText(TR("hostname"), const_cast<char*>(Addr.c_str()), 128, ImGuiInputTextFlags_ReadOnly);
 	}
 
 	ImGui::Separator();

--- a/Source/Gui/Windows/SdlWindow.hpp
+++ b/Source/Gui/Windows/SdlWindow.hpp
@@ -45,15 +45,15 @@ public:
 
 	~WSdlWindow() override = default;
 
-	WMainWindow* GetMainWindow() { return MainWindow.get(); }
+	[[nodiscard]] WMainWindow* GetMainWindow() const { return MainWindow.get(); }
 
-	SDL_Window* GetWindow() const { return Window; }
+	[[nodiscard]] SDL_Window* GetWindow() const { return Window; }
 
 	void Destroy();
 
 	void SetTitle(std::string const& Title) const;
 
-	float GetMainScale() const { return MainScale; }
+	[[nodiscard]] float GetMainScale() const { return MainScale; }
 	void  SetMainScale(float Scale) { MainScale = Scale; }
 
 	void RequestClose() { bShouldClose = true; }
@@ -62,7 +62,7 @@ public:
 	static ImVec2 ScaleSize(ImVec2 const& Size)
 	{
 		float Scale = GetInstance().GetMainScale();
-		return ImVec2(Size.x * Scale, Size.y * Scale);
+		return { Size.x * Scale, Size.y * Scale };
 	}
 
 	static float ScaleValue(float Value) { return Value * GetInstance().GetMainScale(); }

--- a/Source/Gui/Windows/TrafficTree.cpp
+++ b/Source/Gui/Windows/TrafficTree.cpp
@@ -27,6 +27,7 @@
 #include "Format.hpp"
 #include "SdlWindow.hpp"
 #include "Messages.hpp"
+#include "Data/ResolveData.hpp"
 #include "Data/TrafficTreeUpdate.hpp"
 #include "Icons/IconAtlas.hpp"
 #include "Util/I18n.hpp"
@@ -619,16 +620,27 @@ void WTrafficTree::Draw(ImGuiID MainID)
 	ImGui::End();
 }
 
-void WTrafficTree::SetResolvedAddresses(WBuffer const& Buffer)
+void WTrafficTree::HandleResolveResponse(WBuffer const& Buffer)
 {
-	std::unordered_map<WIPAddress, std::string> NewResolvedAddresses{};
-	std::stringstream                           SS;
-	SS.write(Buffer.GetData(), static_cast<long int>(Buffer.GetWritePos()));
+	WResolveResponse ResolveResponse{};
+	if (WClient::ReadMessage(Buffer, ResolveResponse))
 	{
-		SS.seekg(1); // Skip message type
-		cereal::BinaryInputArchive Iar(SS);
-		Iar(NewResolvedAddresses);
+		std::lock_guard Lock(DataMutex);
+		ResolvedAddresses[ResolveResponse.AddressToResolve] = ResolveResponse.ResolveResult;
 	}
-	std::lock_guard Lock(DataMutex);
-	ResolvedAddresses = std::move(NewResolvedAddresses);
+}
+
+std::string const& WTrafficTree::ResolveAddress(WIPAddress const& Address)
+{
+	static std::string Empty{};
+	std::scoped_lock   Lock(DataMutex);
+	if (auto It = ResolvedAddresses.find(Address); It != ResolvedAddresses.end())
+	{
+		return It->second;
+	}
+	ResolvedAddresses[Address] = Empty;
+	WResolveRequest Request;
+	Request.AddressToResolve = Address;
+	WClient::GetInstance().SendMessage(MT_ResolveRequest, Request);
+	return Empty;
 }

--- a/Source/Gui/Windows/TrafficTree.cpp
+++ b/Source/Gui/Windows/TrafficTree.cpp
@@ -306,10 +306,6 @@ void WTrafficTree::UpdateFromBuffer(WBuffer const& Buffer)
 			App->ApplicationPath = Addition.ApplicationPath;
 			Root->Applications[Addition.ApplicationPath] = App;
 			TrafficItems[App->ItemId] = App;
-			if (!ResolvedAddresses.contains(Addition.SocketTuple.RemoteEndpoint.Address))
-			{
-				ResolvedAddresses[Addition.SocketTuple.RemoteEndpoint.Address] = Addition.ResolvedAddress;
-			}
 		}
 		else
 		{
@@ -360,11 +356,6 @@ void WTrafficTree::UpdateFromBuffer(WBuffer const& Buffer)
 			NewTuple->ItemId = Addition.ItemId;
 			SocketItem->UDPPerConnectionTraffic[Addition.Endpoint] = NewTuple;
 			TrafficItems[Addition.ItemId] = NewTuple;
-
-			if (!ResolvedAddresses.contains(Addition.Endpoint.Address))
-			{
-				ResolvedAddresses[Addition.Endpoint.Address] = Addition.ResolvedAddress;
-			}
 		}
 	}
 

--- a/Source/Gui/Windows/TrafficTree.hpp
+++ b/Source/Gui/Windows/TrafficTree.hpp
@@ -54,9 +54,9 @@ public:
 	void UpdateFromBuffer(WBuffer const& Buffer);
 	void Draw(ImGuiID MainID);
 
-	void SetResolvedAddresses(WBuffer const& Buffer);
+	void HandleResolveResponse(WBuffer const& Buffer);
 
-	std::unordered_map<WIPAddress, std::string> const& GetResolvedAddresses() const { return ResolvedAddresses; }
+	std::string const& ResolveAddress(WIPAddress const& Address);
 
 	template <class T>
 	std::shared_ptr<T> GetSeletedTrafficItem()

--- a/Source/Util/Data/CMakeLists.txt
+++ b/Source/Util/Data/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(util
         AppIconAtlasData.hpp
         TrafficTreeUpdate.hpp
         ConnectionHistoryUpdate.hpp
+        ResolveData.hpp
 )
 
 if (UNIX AND NOT APPLE AND NOT EMSCRIPTEN)

--- a/Source/Util/Data/ResolveData.hpp
+++ b/Source/Util/Data/ResolveData.hpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026, Alex <uni@vrsal.cc>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#pragma once
+#include "IPAddress.hpp"
+
+struct WResolveRequest
+{
+	WIPAddress AddressToResolve;
+
+	template <class Archive>
+	void serialize(Archive& archive)
+	{
+		archive(AddressToResolve);
+	}
+};
+
+struct WResolveResponse
+{
+	WIPAddress  AddressToResolve;
+	std::string ResolveResult;
+
+	template <class Archive>
+	void serialize(Archive& archive)
+	{
+		archive(AddressToResolve, ResolveResult);
+	}
+};

--- a/Source/Util/Data/TrafficTreeUpdate.hpp
+++ b/Source/Util/Data/TrafficTreeUpdate.hpp
@@ -45,7 +45,6 @@ struct WTrafficTreeSocketAddition
 	std::string            ApplicationPath{};
 	std::string            ApplicationName{};
 	std::string            ApplicationCommandLine{};
-	std::string            ResolvedAddress{};
 	WSocketTuple           SocketTuple{};
 	ESocketConnectionState ConnectionState{};
 	uint8_t                SocketType{};
@@ -54,7 +53,7 @@ struct WTrafficTreeSocketAddition
 	void serialize(Archive& archive)
 	{
 		archive(ItemId, ProcessItemId, ApplicationItemId, ProcessId, ApplicationName, ApplicationPath,
-			ApplicationCommandLine, SocketTuple, ConnectionState, ResolvedAddress, SocketType);
+			ApplicationCommandLine, SocketTuple, ConnectionState, SocketType);
 	}
 };
 
@@ -63,12 +62,11 @@ struct WTrafficTreeTupleAddition
 	WTrafficItemId ItemId{};
 	WTrafficItemId SocketItemId{};
 	WEndpoint      Endpoint{};
-	std::string    ResolvedAddress{};
 
 	template <class Archive>
 	void serialize(Archive& archive)
 	{
-		archive(ItemId, SocketItemId, Endpoint, ResolvedAddress);
+		archive(ItemId, SocketItemId, Endpoint);
 	}
 };
 

--- a/Source/Util/Messages.hpp
+++ b/Source/Util/Messages.hpp
@@ -10,7 +10,6 @@ enum EMessageType : int8_t
 {
 	MT_Invalid = -1,
 	MT_TrafficTree,
-	MT_ResolvedAddresses,
 	MT_TrafficTreeUpdate,
 	MT_AppIconAtlasData,
 	MT_RuleUpdate,
@@ -18,6 +17,8 @@ enum EMessageType : int8_t
 	MT_ConnectionHistory,
 	MT_ConnectionHistoryUpdate,
 	MT_MemoryStats,
+	MT_ResolveRequest,
+	MT_ResolveResponse,
 
 	MT_Count
 };

--- a/Source/Util/Promise.hpp
+++ b/Source/Util/Promise.hpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026, Alex <uni@vrsal.cc>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#pragma once
+#include <functional>
+#include <memory>
+#include <future>
+
+template <typename T>
+class TPromise
+{
+	struct WSharedState
+	{
+		std::function<void(T)> Callback;
+		std::promise<void>     CallbackReady;
+	};
+
+	std::shared_ptr<WSharedState> SharedState;
+
+public:
+	TPromise() { SharedState = std::make_shared<WSharedState>(); }
+	virtual ~TPromise() {}
+
+	void Finish(T const& Result) const
+	{
+		SharedState->CallbackReady.get_future().wait();
+		SharedState->Callback(Result);
+	}
+
+	void Then(std::function<void(T)> Callback)
+	{
+		SharedState->Callback = Callback;
+		SharedState->CallbackReady.set_value();
+	}
+};

--- a/Source/Util/Promise.hpp
+++ b/Source/Util/Promise.hpp
@@ -6,32 +6,40 @@
 #pragma once
 #include <functional>
 #include <memory>
-#include <future>
+#include <mutex>
+#include <condition_variable>
 
 template <typename T>
 class TPromise
 {
 	struct WSharedState
 	{
-		std::function<void(T)> Callback;
-		std::promise<void>     CallbackReady;
+		std::function<void(T)>  Callback;
+		std::mutex              Mutex;
+		std::condition_variable CV;
+		bool                    Ready = false;
 	};
 
 	std::shared_ptr<WSharedState> SharedState;
 
 public:
 	TPromise() { SharedState = std::make_shared<WSharedState>(); }
-	virtual ~TPromise() {}
+	virtual ~TPromise() = default;
 
 	void Finish(T const& Result) const
 	{
-		SharedState->CallbackReady.get_future().wait();
+		std::unique_lock Lock(SharedState->Mutex);
+		SharedState->CV.wait(Lock, [this] { return SharedState->Ready; });
 		SharedState->Callback(Result);
 	}
 
 	void Then(std::function<void(T)> Callback)
 	{
-		SharedState->Callback = Callback;
-		SharedState->CallbackReady.set_value();
+		{
+			std::scoped_lock Lock(SharedState->Mutex);
+			SharedState->Callback = Callback;
+			SharedState->Ready = true;
+		}
+		SharedState->CV.notify_one();
 	}
 };


### PR DESCRIPTION
Instead of resolving everything always and fill up the cache with useless info this change now only resolves ip address to hostnames if a client requests it, i.e. clicks a socket.

Closes #102 