### PR TITLE
Map fixes

### DIFF
--- a/.github/scripts/windows/configure.ps1
+++ b/.github/scripts/windows/configure.ps1
@@ -2,7 +2,7 @@
 $ErrorActionPreference = "Stop"
 
 Write-Host "Configuring CMake..."
-cmake -S . -B build -G "Visual Studio 17 2022" -A x64 `
+cmake -S . -B build -G "Visual Studio 18 2026" -A x64 `
   -DCMAKE_BUILD_TYPE=Release `
   -DCMAKE_TOOLCHAIN_FILE="vcpkg/scripts/buildsystems/vcpkg.cmake" `
   -DWAECHTER_BUILD_DAEMON=OFF `

--- a/Source/Daemon/Data/Counters.cpp
+++ b/Source/Daemon/Data/Counters.cpp
@@ -86,7 +86,7 @@ void WSocketCounter::ProcessSocketEvent(WSocketEvent const& Event) const
 		{
 			TrafficItem->SocketType |= ESocketType::Connect;
 		}
-		else
+		else if (TrafficItem->SocketTuple.Protocol == EProtocol::UDP)
 		{
 			TrafficItem->SocketType |= ESocketType::Listen;
 		}
@@ -101,7 +101,7 @@ void WSocketCounter::ProcessSocketEvent(WSocketEvent const& Event) const
 		{
 			TrafficItem->SocketType |= ESocketType::Connect;
 		}
-		else
+		else if (TrafficItem->SocketTuple.Protocol == EProtocol::UDP)
 		{
 			TrafficItem->SocketType |= ESocketType::Listen;
 		}

--- a/Source/Daemon/Data/Counters.cpp
+++ b/Source/Daemon/Data/Counters.cpp
@@ -11,6 +11,7 @@
 
 void WSocketCounter::ProcessSocketEvent(WSocketEvent const& Event) const
 {
+	auto const OldItemState = *TrafficItem.get();
 	if (Event.EventType == NE_SocketConnect_4 && TrafficItem->ConnectionState != ESocketConnectionState::Connecting)
 	{
 		TrafficItem->ConnectionState = ESocketConnectionState::Connecting;
@@ -164,6 +165,9 @@ void WSocketCounter::ProcessSocketEvent(WSocketEvent const& Event) const
 		WNetworkEvents::GetInstance().OnSocketConnected(this);
 	}
 
-	WSystemMap::GetInstance().GetMapUpdate().AddStateChange(
-		TrafficItem->ItemId, TrafficItem->ConnectionState, TrafficItem->SocketType, TrafficItem->SocketTuple);
+	if (OldItemState != *TrafficItem.get())
+	{
+		WSystemMap::GetInstance().GetMapUpdate().AddStateChange(TrafficItem->ItemId, TrafficItem->ConnectionState,
+			TrafficItem->SocketType, std::make_shared<WSocketTuple>(TrafficItem->SocketTuple));
+	}
 }

--- a/Source/Daemon/Data/MapUpdate.cpp
+++ b/Source/Daemon/Data/MapUpdate.cpp
@@ -23,7 +23,7 @@ bool WMapUpdate::TrackUpdates()
 }
 
 void WMapUpdate::AddStateChange(WTrafficItemId const Id, ESocketConnectionState const NewState,
-	uint8_t const SocketType, std::optional<WSocketTuple> const& SocketTuple)
+	uint8_t const SocketType, std::shared_ptr<WSocketTuple> const& SocketTuple)
 {
 	if (!TrackUpdates())
 	{

--- a/Source/Daemon/Data/MapUpdate.hpp
+++ b/Source/Daemon/Data/MapUpdate.hpp
@@ -61,7 +61,7 @@ public:
 	}
 
 	void AddStateChange(WTrafficItemId Id, ESocketConnectionState NewState, uint8_t SocketType,
-		std::optional<WSocketTuple> const& SocketTuple = std::nullopt);
+		std::shared_ptr<WSocketTuple> const& SocketTuple = nullptr);
 
 	void AddTupleAddition(WEndpoint const& Endpoint, std::shared_ptr<WTupleCounter> const& Tuple)
 	{

--- a/Source/Daemon/Data/SystemMap.cpp
+++ b/Source/Daemon/Data/SystemMap.cpp
@@ -21,7 +21,6 @@
 #include "Db/StatsManager.hpp"
 #include "Net/IPLink.hpp"
 #include "Net/PacketParser.hpp"
-#include "Net/Resolver.hpp"
 
 static std::string NormalizeAppImagePaths(std::string const& path);
 
@@ -146,8 +145,6 @@ void WSystemMap::DoPacketParsing(WSocketEvent const& Event, std::shared_ptr<WSoc
 				}
 			}
 		}
-
-		MapUpdate.AddStateChange(Item->ItemId, ESocketConnectionState::Connected, Item->SocketType, Item->SocketTuple);
 		if (bItemModified)
 		{
 			MapUpdate.AddStateChange(Item->ItemId, Item->ConnectionState, Item->SocketType,

--- a/Source/Daemon/Data/SystemMap.cpp
+++ b/Source/Daemon/Data/SystemMap.cpp
@@ -93,8 +93,8 @@ void WSystemMap::DoPacketParsing(WSocketEvent const& Event, std::shared_ptr<WSoc
 			else
 			{
 				ZoneScopedN("DetermineSocketType");
-				auto const DeterminedType =
-					SocketStateParser.DetermineSocketType(Item->SocketTuple.LocalEndpoint, Item->SocketTuple.Protocol);
+				auto const DeterminedType = SocketStateParser.DetermineSocketType(
+					Item->SocketTuple.LocalEndpoint, Item->SocketTuple.Protocol, &RemoteEndpoint);
 
 				if (Item->SocketType != DeterminedType)
 				{

--- a/Source/Daemon/Data/SystemMap.cpp
+++ b/Source/Daemon/Data/SystemMap.cpp
@@ -45,6 +45,7 @@ void WSystemMap::DoPacketParsing(WSocketEvent const& Event, std::shared_ptr<WSoc
 
 	if (PacketHeader.ParsePacket(Event.Data.TrafficEventData.RawData, PACKET_HEADER_SIZE))
 	{
+		bool bItemModified = false;
 		Item->SocketTuple.Protocol = PacketHeader.L4Proto;
 		WEndpoint LocalEndpoint;
 		WEndpoint RemoteEndpoint;
@@ -62,6 +63,10 @@ void WSystemMap::DoPacketParsing(WSocketEvent const& Event, std::shared_ptr<WSoc
 
 		if (!bHaveLocalEndpoint)
 		{
+			if (Item->SocketTuple.LocalEndpoint != LocalEndpoint)
+			{
+				bItemModified = true;
+			}
 			Item->SocketTuple.LocalEndpoint = LocalEndpoint;
 		}
 
@@ -69,6 +74,10 @@ void WSystemMap::DoPacketParsing(WSocketEvent const& Event, std::shared_ptr<WSoc
 		// is if they explicitly connect() to an address
 		if (!bHaveRemoteEndpoint && Item->SocketTuple.Protocol != EProtocol::UDP)
 		{
+			if (Item->SocketTuple.RemoteEndpoint != RemoteEndpoint)
+			{
+				bItemModified = true;
+			}
 			Item->SocketTuple.RemoteEndpoint = RemoteEndpoint;
 		}
 
@@ -76,13 +85,24 @@ void WSystemMap::DoPacketParsing(WSocketEvent const& Event, std::shared_ptr<WSoc
 		{
 			if (Item->SocketTuple.Protocol == EProtocol::ICMP || Item->SocketTuple.Protocol == EProtocol::ICMPv6)
 			{
+				if (Item->SocketType != ESocketType::Connect)
+				{
+					bItemModified = true;
+				}
 				Item->SocketType = ESocketType::Connect;
 			}
 			else
 			{
 				ZoneScopedN("DetermineSocketType");
-				Item->SocketType =
+				auto const DeterminedType =
 					SocketStateParser.DetermineSocketType(Item->SocketTuple.LocalEndpoint, Item->SocketTuple.Protocol);
+
+				if (Item->SocketType != DeterminedType)
+				{
+					bItemModified = true;
+				}
+
+				Item->SocketType = DeterminedType;
 			}
 		}
 
@@ -91,8 +111,8 @@ void WSystemMap::DoPacketParsing(WSocketEvent const& Event, std::shared_ptr<WSoc
 			// Add a new UDP per-connection tuple if the remote endpoint is different from the socket's main one
 			if (!RemoteEndpoint.Address.IsZero())
 			{
-				bool bTupleExists = Item->UDPPerConnectionTraffic.contains(RemoteEndpoint);
-				auto TupleCounter = GetOrCreateUDPTupleCounter(SockCounter, RemoteEndpoint);
+				bool const bTupleExists = Item->UDPPerConnectionTraffic.contains(RemoteEndpoint);
+				auto const TupleCounter = GetOrCreateUDPTupleCounter(SockCounter, RemoteEndpoint);
 				if (Event.Data.TrafficEventData.Direction == PD_Outgoing)
 				{
 					ZoneScopedN("PushOutgoingTraffic");
@@ -128,6 +148,11 @@ void WSystemMap::DoPacketParsing(WSocketEvent const& Event, std::shared_ptr<WSoc
 		}
 
 		MapUpdate.AddStateChange(Item->ItemId, ESocketConnectionState::Connected, Item->SocketType, Item->SocketTuple);
+		if (bItemModified)
+		{
+			MapUpdate.AddStateChange(Item->ItemId, Item->ConnectionState, Item->SocketType,
+				std::make_shared<WSocketTuple>(Item->SocketTuple));
+		}
 	}
 	else
 	{

--- a/Source/Daemon/Data/SystemMap.cpp
+++ b/Source/Daemon/Data/SystemMap.cpp
@@ -344,6 +344,11 @@ WSystemMap::WSystemMap()
 		SystemItem->HostName = HostName;
 	}
 	RegisterDefaultFilters();
+	// Periodically check /proc/ for any socket info
+	WTimerManager::GetInstance().AddTimer(5, [this] {
+		std::scoped_lock Lock(DataMutex);
+		SocketStateParser.ParseData();
+	});
 }
 
 static std::string NormalizeAppImagePaths(std::string const& path)
@@ -467,6 +472,88 @@ std::shared_ptr<WSocketCounter> WSystemMap::MapSocket(WSocketEvent const& Event,
 	auto const Process = FindOrMapProcess(PID, App);
 	assert(Process);
 	return FindOrMapSocket(SocketCookie, Process);
+}
+
+std::shared_ptr<WSocketCounter> WSystemMap::MapSocketFromTrafficEvent(WSocketEvent const& Event)
+{
+	ZoneScopedN("WSystemMap::MapSocketFromTrafficEvent");
+
+	WPacketHeaderParser PacketHeader{};
+	if (!PacketHeader.ParsePacket(Event.Data.TrafficEventData.RawData, PACKET_HEADER_SIZE))
+	{
+		spdlog::warn("Failed to map unknown socket {} from traffic: packet header parsing failed", Event.Cookie);
+		return {};
+	}
+
+	auto const LocalEndpoint =
+		Event.Data.TrafficEventData.Direction == PD_Outgoing ? PacketHeader.Src : PacketHeader.Dst;
+
+	auto const PID = SocketStateParser.GetEndpointPID(LocalEndpoint);
+	if (PID <= 0)
+	{
+		spdlog::debug("Failed to map unknown socket {} from traffic: no PID found for local endpoint {}", Event.Cookie,
+			LocalEndpoint.ToString());
+		return {};
+	}
+
+	auto Socket = MapSocket(Event, PID, false);
+	if (Socket)
+	{
+		if (Socket->TrafficItem->SocketTuple.LocalEndpoint.Address.IsZero()
+			|| Socket->TrafficItem->SocketTuple.LocalEndpoint.Port == 0)
+		{
+			Socket->TrafficItem->SocketTuple.LocalEndpoint = LocalEndpoint;
+		}
+
+		if (Socket->TrafficItem->SocketTuple.Protocol == EProtocol::Unknown)
+		{
+			Socket->TrafficItem->SocketTuple.Protocol = PacketHeader.L4Proto;
+		}
+
+		spdlog::debug(
+			"Mapped unknown socket {} from traffic to PID {} via {}", Event.Cookie, PID, LocalEndpoint.ToString());
+	}
+
+	return Socket;
+}
+
+void WSystemMap::PushTrafficForSocket(WSocketEvent const& Event, std::shared_ptr<WSocketCounter> const& Socket) const
+{
+	auto const Bytes = Event.Data.TrafficEventData.Bytes;
+	if (Event.Data.TrafficEventData.Direction == PD_Incoming)
+	{
+		ZoneScopedN("WSystemMap::PushIncomingTraffic");
+		Socket->PushIncomingTraffic(Bytes);
+		Socket->ParentProcess->PushIncomingTraffic(Bytes);
+		Socket->ParentProcess->ParentApp->PushIncomingTraffic(Bytes);
+
+		for (auto const& Filter : FilterCounters)
+		{
+			if (Filter->FilterFunction(Socket->TrafficItem->ItemId, &Socket->TrafficItem->SocketTuple.LocalEndpoint,
+					&Socket->TrafficItem->SocketTuple.RemoteEndpoint))
+			{
+				Filter->PushIncomingTraffic(Bytes);
+			}
+		}
+	}
+	else
+	{
+		ZoneScopedN("WSystemMap::PushOutgoingTraffic");
+		Socket->PushOutgoingTraffic(Bytes);
+		Socket->ParentProcess->PushOutgoingTraffic(Bytes);
+		Socket->ParentProcess->ParentApp->PushOutgoingTraffic(Bytes);
+
+		for (auto const& Filter : FilterCounters)
+		{
+			if (Filter->FilterFunction(Socket->TrafficItem->ItemId, &Socket->TrafficItem->SocketTuple.LocalEndpoint,
+					&Socket->TrafficItem->SocketTuple.RemoteEndpoint))
+			{
+				Filter->PushOutgoingTraffic(Bytes);
+			}
+		}
+	}
+
+	Socket->TrafficItem->ConnectionState = ESocketConnectionState::Connected;
 }
 
 std::shared_ptr<WSocketCounter> WSystemMap::FindOrMapSocket(
@@ -622,63 +709,58 @@ void WSystemMap::RefreshAllTrafficCounters()
 void WSystemMap::PushIncomingTraffic(WSocketEvent const& Event)
 {
 	auto const       Bytes = Event.Data.TrafficEventData.Bytes;
-	auto             SocketCookie = Event.Cookie;
+	auto const       SocketCookie = Event.Cookie;
 	std::unique_lock Lock(DataMutex);
 	TrafficCounter.PushIncomingTraffic(Bytes);
 
+	std::shared_ptr<WSocketCounter> Socket{};
 	if (auto const It = Sockets.find(SocketCookie); It != Sockets.end())
 	{
-		auto Socket = It->second;
-		{
-			ZoneScopedN("WSystemMap::PushIncomingTraffic");
-			Socket->PushIncomingTraffic(Bytes);
-			Socket->TrafficItem->ConnectionState = ESocketConnectionState::Connected;
-			Socket->ParentProcess->PushIncomingTraffic(Bytes);
-			Socket->ParentProcess->ParentApp->PushIncomingTraffic(Bytes);
-
-			for (auto const& Filter : FilterCounters)
-			{
-				if (Filter->FilterFunction(Socket->TrafficItem->ItemId, &Socket->TrafficItem->SocketTuple.LocalEndpoint,
-						&Socket->TrafficItem->SocketTuple.RemoteEndpoint))
-				{
-					Filter->PushIncomingTraffic(Bytes);
-				}
-			}
-		}
-
-		DoPacketParsing(Event, Socket);
+		Socket = It->second;
 	}
+	else
+	{
+		// We don't know about this socket yet, so we have to create it
+		// Lock.unlock();
+		// Socket = MapSocketFromTrafficEvent(Event);
+		// Lock.lock();
+
+		if (!Socket)
+		{
+			return;
+		}
+	}
+
+	PushTrafficForSocket(Event, Socket);
+	DoPacketParsing(Event, Socket);
 }
 
 void WSystemMap::PushOutgoingTraffic(WSocketEvent const& Event)
 {
 	auto const       Bytes = Event.Data.TrafficEventData.Bytes;
-	auto             SocketCookie = Event.Cookie;
+	auto const       SocketCookie = Event.Cookie;
 	std::unique_lock Lock(DataMutex);
 	TrafficCounter.PushOutgoingTraffic(Bytes);
 
+	std::shared_ptr<WSocketCounter> Socket{};
 	if (auto const It = Sockets.find(SocketCookie); It != Sockets.end())
 	{
-		auto Socket = It->second;
-		{
-			ZoneScopedN("WSystemMap::PushOutgoingTraffic");
-			Socket->PushOutgoingTraffic(Bytes);
-			Socket->TrafficItem->ConnectionState = ESocketConnectionState::Connected;
-			Socket->ParentProcess->PushOutgoingTraffic(Bytes);
-			Socket->ParentProcess->ParentApp->PushOutgoingTraffic(Bytes);
-
-			for (auto const& Filter : FilterCounters)
-			{
-				if (Filter->FilterFunction(Socket->TrafficItem->ItemId, &Socket->TrafficItem->SocketTuple.LocalEndpoint,
-						&Socket->TrafficItem->SocketTuple.RemoteEndpoint))
-				{
-					Filter->PushOutgoingTraffic(Bytes);
-				}
-			}
-		}
-
-		DoPacketParsing(Event, Socket);
+		Socket = It->second;
 	}
+	else
+	{
+		Lock.unlock();
+		Socket = MapSocketFromTrafficEvent(Event);
+		Lock.lock();
+
+		if (!Socket)
+		{
+			return;
+		}
+	}
+
+	PushTrafficForSocket(Event, Socket);
+	DoPacketParsing(Event, Socket);
 }
 
 std::vector<std::string> WSystemMap::GetActiveApplicationPaths()
@@ -888,7 +970,8 @@ void WSystemMap::Cleanup()
 		// Remove sockets in an unknown state
 		else if (IsStaleSocket(Socket))
 		{
-			spdlog::warn("Removing unkown socket with id {}, tuple: {}, app: {}", SocketIt->first,
+			// todo: ideally we would never end up here
+			spdlog::warn("Removing unknown socket with id {}, tuple: {}, app: {}", SocketIt->first,
 				Socket->TrafficItem->SocketTuple.ToString(),
 				Socket->ParentProcess->ParentApp->TrafficItem->ApplicationName);
 			Socket->MarkForRemoval();

--- a/Source/Daemon/Data/SystemMap.cpp
+++ b/Source/Daemon/Data/SystemMap.cpp
@@ -738,7 +738,7 @@ void WSystemMap::PushIncomingTraffic(WSocketEvent const& Event)
 void WSystemMap::PushOutgoingTraffic(WSocketEvent const& Event)
 {
 	auto const       Bytes = Event.Data.TrafficEventData.Bytes;
-	auto const       SocketCookie = Event.Cookie;
+	auto             SocketCookie = Event.Cookie;
 	std::unique_lock Lock(DataMutex);
 	TrafficCounter.PushOutgoingTraffic(Bytes);
 

--- a/Source/Daemon/Data/SystemMap.cpp
+++ b/Source/Daemon/Data/SystemMap.cpp
@@ -235,8 +235,7 @@ void WSystemMap::AddExistingSockets()
 	// instead we add them here manually
 
 	// Use a synthetic cookie range with the high bit set to avoid collision with real EBPF cookies
-	static constexpr WSocketCookie SyntheticCookieBase = static_cast<WSocketCookie>(1) << 63;
-	WSocketCookie                  SyntheticCookie = SyntheticCookieBase;
+	WSocketCookie SyntheticCookie = kSyntheticCookieBase;
 
 	auto const& ListeningSockets = SocketStateParser.GetListeningSockets();
 	for (auto const& [LocalEndpoint, Protocol, PID] : ListeningSockets)

--- a/Source/Daemon/Data/SystemMap.cpp
+++ b/Source/Daemon/Data/SystemMap.cpp
@@ -254,22 +254,15 @@ void WSystemMap::AddExistingSockets()
 		assert(Socket);
 		if (!Socket)
 		{
-			spdlog::error("Failed to map existing listen socket for PID {} and endpoint {}, skipping", ListenSocket.PID,
-				ListenSocket.LocalEndpoint.ToString());
 			spdlog::error("Failed to map existing listen socket for PID {} and endpoint {}, skipping", PID,
 				LocalEndpoint.ToString());
 			continue;
 		}
-		Socket->TrafficItem->SocketTuple.LocalEndpoint = ListenSocket.LocalEndpoint;
-		Socket->TrafficItem->SocketTuple.Protocol = ListenSocket.Protocol;
 		Socket->TrafficItem->SocketTuple.LocalEndpoint = LocalEndpoint;
 		Socket->TrafficItem->SocketTuple.Protocol = Protocol;
 		Socket->TrafficItem->SocketType = ESocketType::Listen;
 		Socket->TrafficItem->ConnectionState = ESocketConnectionState::Connected;
 
-		spdlog::debug("Added existing listen socket: {} {} (PID {}, app '{}')",
-			EProtocol::ToString(ListenSocket.Protocol), ListenSocket.LocalEndpoint.ToString(), ListenSocket.PID,
-			Socket->ParentProcess->ParentApp->TrafficItem->ApplicationName);
 		spdlog::debug("Added existing listen socket: {} {} (PID {}, app '{}')", EProtocol::ToString(Protocol),
 			LocalEndpoint.ToString(), PID, Socket->ParentProcess->ParentApp->TrafficItem->ApplicationName);
 	}
@@ -628,9 +621,9 @@ void WSystemMap::RefreshAllTrafficCounters()
 
 void WSystemMap::PushIncomingTraffic(WSocketEvent const& Event)
 {
-	auto            SocketCookie = Event.Cookie;
-	std::lock_guard Lock(DataMutex);
 	auto const       Bytes = Event.Data.TrafficEventData.Bytes;
+	auto             SocketCookie = Event.Cookie;
+	std::unique_lock Lock(DataMutex);
 	TrafficCounter.PushIncomingTraffic(Bytes);
 
 	if (auto const It = Sockets.find(SocketCookie); It != Sockets.end())
@@ -659,9 +652,9 @@ void WSystemMap::PushIncomingTraffic(WSocketEvent const& Event)
 
 void WSystemMap::PushOutgoingTraffic(WSocketEvent const& Event)
 {
-	auto            SocketCookie = Event.Cookie;
-	std::lock_guard Lock(DataMutex);
 	auto const       Bytes = Event.Data.TrafficEventData.Bytes;
+	auto             SocketCookie = Event.Cookie;
+	std::unique_lock Lock(DataMutex);
 	TrafficCounter.PushOutgoingTraffic(Bytes);
 
 	if (auto const It = Sockets.find(SocketCookie); It != Sockets.end())

--- a/Source/Daemon/Data/SystemMap.cpp
+++ b/Source/Daemon/Data/SystemMap.cpp
@@ -26,7 +26,7 @@ static std::string NormalizeAppImagePaths(std::string const& path);
 
 void WSystemMap::DoPacketParsing(WSocketEvent const& Event, std::shared_ptr<WSocketCounter> const& SockCounter)
 {
-	auto Item = SockCounter->TrafficItem;
+	auto const Item = SockCounter->TrafficItem;
 	// if this socket doesn't already have a local/remote endpoint, try to infer from traffic
 	bool const bHaveLocalEndpoint = !Item->SocketTuple.LocalEndpoint.Address.IsZero();
 	bool const bHaveRemoteEndpoint = !Item->SocketTuple.RemoteEndpoint.Address.IsZero();
@@ -160,8 +160,8 @@ void WSystemMap::DoPacketParsing(WSocketEvent const& Event, std::shared_ptr<WSoc
 std::shared_ptr<WTupleCounter> WSystemMap::GetOrCreateUDPTupleCounter(
 	std::shared_ptr<WSocketCounter> const& SockCounter, WEndpoint const& Endpoint)
 {
-	auto Item = SockCounter->TrafficItem;
-	if (auto It = SockCounter->UDPPerConnectionCounters.find(Endpoint);
+	auto const Item = SockCounter->TrafficItem;
+	if (auto const It = SockCounter->UDPPerConnectionCounters.find(Endpoint);
 		It != SockCounter->UDPPerConnectionCounters.end())
 	{
 		return It->second;
@@ -239,9 +239,9 @@ void WSystemMap::AddExistingSockets()
 	WSocketCookie                  SyntheticCookie = SyntheticCookieBase;
 
 	auto const& ListeningSockets = SocketStateParser.GetListeningSockets();
-	for (auto const& ListenSocket : ListeningSockets)
+	for (auto const& [LocalEndpoint, Protocol, PID] : ListeningSockets)
 	{
-		if (ListenSocket.PID <= 0 || !WFilesystem::IsProcessRunning(ListenSocket.PID))
+		if (PID <= 0 || !WFilesystem::IsProcessRunning(PID))
 		{
 			continue;
 		}
@@ -250,22 +250,28 @@ void WSystemMap::AddExistingSockets()
 		SyntheticEvent.Cookie = SyntheticCookie++;
 		SyntheticEvent.EventType = NE_Synthetic;
 
-		auto const Socket = MapSocket(SyntheticEvent, ListenSocket.PID, false);
+		auto const Socket = MapSocket(SyntheticEvent, PID, false);
 		assert(Socket);
 		if (!Socket)
 		{
 			spdlog::error("Failed to map existing listen socket for PID {} and endpoint {}, skipping", ListenSocket.PID,
 				ListenSocket.LocalEndpoint.ToString());
+			spdlog::error("Failed to map existing listen socket for PID {} and endpoint {}, skipping", PID,
+				LocalEndpoint.ToString());
 			continue;
 		}
 		Socket->TrafficItem->SocketTuple.LocalEndpoint = ListenSocket.LocalEndpoint;
 		Socket->TrafficItem->SocketTuple.Protocol = ListenSocket.Protocol;
+		Socket->TrafficItem->SocketTuple.LocalEndpoint = LocalEndpoint;
+		Socket->TrafficItem->SocketTuple.Protocol = Protocol;
 		Socket->TrafficItem->SocketType = ESocketType::Listen;
 		Socket->TrafficItem->ConnectionState = ESocketConnectionState::Connected;
 
 		spdlog::debug("Added existing listen socket: {} {} (PID {}, app '{}')",
 			EProtocol::ToString(ListenSocket.Protocol), ListenSocket.LocalEndpoint.ToString(), ListenSocket.PID,
 			Socket->ParentProcess->ParentApp->TrafficItem->ApplicationName);
+		spdlog::debug("Added existing listen socket: {} {} (PID {}, app '{}')", EProtocol::ToString(Protocol),
+			LocalEndpoint.ToString(), PID, Socket->ParentProcess->ParentApp->TrafficItem->ApplicationName);
 	}
 
 	spdlog::info("Added {} existing listen sockets.", ListeningSockets.size());
@@ -283,7 +289,7 @@ void WSystemMap::ReparentOrphanedSocket(WEndpoint const& Endpoint, WProcessId Ne
 			return;
 		}
 
-		auto App = It->second->ParentProcess->ParentApp;
+		auto const App = It->second->ParentProcess->ParentApp;
 
 		// Re-register the application if it was cleaned up while the socket was orphaned
 		auto const& AppKey = App->TrafficItem->ApplicationPath;
@@ -294,8 +300,8 @@ void WSystemMap::ReparentOrphanedSocket(WEndpoint const& Endpoint, WProcessId Ne
 			TrafficItems[App->TrafficItem->ItemId] = App->TrafficItem;
 		}
 
-		auto bExistingProcess = Processes.contains(NewParentProcess);
-		auto NewProcess = FindOrMapProcess(NewParentProcess, App);
+		auto const bExistingProcess = Processes.contains(NewParentProcess);
+		auto const NewProcess = FindOrMapProcess(NewParentProcess, App);
 		It->second->ParentProcess = NewProcess;
 		NewProcess->TrafficItem->Sockets[It->second->TrafficItem->ItemId] = It->second->TrafficItem;
 		Sockets[It->second->TrafficItem->Cookie] = It->second;
@@ -339,7 +345,7 @@ void WSystemMap::ReparentAcceptedSocket(std::shared_ptr<WSocketCounter> const& S
 
 WSystemMap::WSystemMap()
 {
-	auto HostName = WFilesystem::ReadProc("/proc/sys/kernel/hostname");
+	auto const HostName = WFilesystem::ReadProc("/proc/sys/kernel/hostname");
 	if (!HostName.empty())
 	{
 		SystemItem->HostName = HostName;
@@ -353,7 +359,7 @@ static std::string NormalizeAppImagePaths(std::string const& path)
 	return std::regex_replace(path, RE, "/tmp/appimage/bin/$1");
 }
 
-std::shared_ptr<WSocketCounter> WSystemMap::MapSocket(WSocketEvent const& Event, WProcessId PID, bool bSilentFail)
+std::shared_ptr<WSocketCounter> WSystemMap::MapSocket(WSocketEvent const& Event, WProcessId PID, bool const bSilentFail)
 {
 	std::scoped_lock Lock(DataMutex);
 
@@ -380,7 +386,7 @@ std::shared_ptr<WSocketCounter> WSystemMap::MapSocket(WSocketEvent const& Event,
 		return {};
 	}
 
-	if (auto It = Sockets.find(SocketCookie); It != Sockets.end())
+	if (auto const It = Sockets.find(SocketCookie); It != Sockets.end())
 	{
 		return It->second;
 	}
@@ -425,11 +431,10 @@ std::shared_ptr<WSocketCounter> WSystemMap::MapSocket(WSocketEvent const& Event,
 			}
 
 			// Resolve relative path
-			std::string ResolvedPath = Cwd + Argv[0];
+			std::string const ResolvedPath = Cwd + Argv[0];
 
 			// Try to resolve the path to see if it exists
-			char* RealPath = realpath(ResolvedPath.c_str(), nullptr);
-			if (RealPath)
+			if (char* RealPath = realpath(ResolvedPath.c_str(), nullptr))
 			{
 				ExePath = NormalizeAppImagePaths(RealPath);
 				free(RealPath);
@@ -456,23 +461,23 @@ std::shared_ptr<WSocketCounter> WSystemMap::MapSocket(WSocketEvent const& Event,
 	if ((Comm.empty() || Comm == "main" || Comm == "Main") && !ExePath.empty())
 	{
 		// derive basename
-		auto Pos = ExePath.find_last_of('/');
-		Comm = WStringFormat::Trim((Pos == std::string::npos) ? ExePath : ExePath.substr(Pos + 1));
+		auto const Pos = ExePath.find_last_of('/');
+		Comm = WStringFormat::Trim(Pos == std::string::npos ? ExePath : ExePath.substr(Pos + 1));
 		if (Comm.empty())
 		{
 			Comm = ExePath.empty() ? "unknown" : ExePath;
 		}
 	}
 
-	auto App = FindOrMapApplication(ExePath, CmdlIne, Comm);
+	auto const App = FindOrMapApplication(ExePath, CmdlIne, Comm);
 	assert(App);
-	auto Process = FindOrMapProcess(PID, App);
+	auto const Process = FindOrMapProcess(PID, App);
 	assert(Process);
 	return FindOrMapSocket(SocketCookie, Process);
 }
 
 std::shared_ptr<WSocketCounter> WSystemMap::FindOrMapSocket(
-	WSocketCookie SocketCookie, std::shared_ptr<WProcessCounter> const& ParentProcess)
+	WSocketCookie const SocketCookie, std::shared_ptr<WProcessCounter> const& ParentProcess)
 {
 	ZoneScopedN("WSystemMap::FindOrMapSocket");
 	if (auto const It = Sockets.find(SocketCookie); It != Sockets.end())
@@ -528,14 +533,14 @@ std::shared_ptr<WAppCounter> WSystemMap::FindOrMapApplication(
 		Key = CommandLine;
 	}
 
-	if (auto Pos = Key.find(' '); Pos != std::string::npos)
+	if (auto const Pos = Key.find(' '); Pos != std::string::npos)
 	{
 		Key = NormalizeAppImagePaths(Key.substr(0, Pos));
 	}
 
 	Key = WStringFormat::Trim(Key);
 
-	if (auto It = Applications.find(Key); It != Applications.end())
+	if (auto const It = Applications.find(Key); It != Applications.end())
 	{
 		return It->second;
 	}
@@ -554,8 +559,8 @@ std::shared_ptr<WAppCounter> WSystemMap::FindOrMapApplication(
 	else
 	{
 		// derive basename
-		auto Pos = Key.find_last_of('/');
-		AppItem->ApplicationName = WStringFormat::Trim((Pos == std::string::npos) ? Key : Key.substr(Pos + 1));
+		auto const Pos = Key.find_last_of('/');
+		AppItem->ApplicationName = WStringFormat::Trim(Pos == std::string::npos ? Key : Key.substr(Pos + 1));
 		if (AppItem->ApplicationName.empty())
 		{
 			AppItem->ApplicationName = Key.empty() ? "unknown" : Key;
@@ -563,7 +568,7 @@ std::shared_ptr<WAppCounter> WSystemMap::FindOrMapApplication(
 	}
 
 	bool bHaveCachedIcon{ false };
-	auto IconPath =
+	auto const IconPath =
 		WAppIconAtlasBuilder::GetInstance().GetResolver().ResolveIcon(AppItem->ApplicationName, &bHaveCachedIcon);
 
 	if (!IconPath.empty() && !bHaveCachedIcon)
@@ -623,9 +628,9 @@ void WSystemMap::RefreshAllTrafficCounters()
 
 void WSystemMap::PushIncomingTraffic(WSocketEvent const& Event)
 {
-	auto            Bytes = Event.Data.TrafficEventData.Bytes;
 	auto            SocketCookie = Event.Cookie;
 	std::lock_guard Lock(DataMutex);
+	auto const       Bytes = Event.Data.TrafficEventData.Bytes;
 	TrafficCounter.PushIncomingTraffic(Bytes);
 
 	if (auto const It = Sockets.find(SocketCookie); It != Sockets.end())
@@ -654,9 +659,9 @@ void WSystemMap::PushIncomingTraffic(WSocketEvent const& Event)
 
 void WSystemMap::PushOutgoingTraffic(WSocketEvent const& Event)
 {
-	auto            Bytes = Event.Data.TrafficEventData.Bytes;
 	auto            SocketCookie = Event.Cookie;
 	std::lock_guard Lock(DataMutex);
+	auto const       Bytes = Event.Data.TrafficEventData.Bytes;
 	TrafficCounter.PushOutgoingTraffic(Bytes);
 
 	if (auto const It = Sockets.find(SocketCookie); It != Sockets.end())
@@ -709,9 +714,9 @@ WMemoryStat WSystemMap::GetMemoryUsage()
 
 	Apps.Name = "Applications";
 	Apps.Usage += sizeof(decltype(Applications));
-	for (auto const& App : Applications)
+	for (auto const& AppPath : Applications | std::views::keys)
 	{
-		Apps.Usage += App.first.capacity();
+		Apps.Usage += AppPath.capacity();
 		Apps.Usage += sizeof(WAppCounter);
 		Apps.Usage += sizeof(WApplicationItem);
 	}
@@ -759,7 +764,7 @@ void WSystemMap::Cleanup()
 
 	for (auto ProcessIt = Processes.begin(); ProcessIt != Processes.end();)
 	{
-		auto PID = ProcessIt->first;
+		auto const PID = ProcessIt->first;
 		if (!WFilesystem::IsProcessRunning(PID) && !ProcessIt->second->IsMarkedForRemoval())
 		{
 			ProcessIt->second->MarkForRemoval();
@@ -775,7 +780,7 @@ void WSystemMap::Cleanup()
 
 			// If this process exited, but there are still open sockets left,
 			// they most likely now belong to a child process. Since those
-			// processes might be running as root and we are not running as root
+			// processes might be running as root, and we are not running as root
 			// we can't look them up via /proc/. So instead we sent these endpoints
 			// to the ip link process which does run as root, which will check
 			// what processes (if any) own these ports now. Not exactly a good
@@ -855,8 +860,8 @@ void WSystemMap::Cleanup()
 		// If the socket's local port is not in use anymore, we consider it stale (except for ICMP which doesn't have
 		// ports)
 		if (!SocketStateParser.IsUsedPort(Socket->TrafficItem->SocketTuple.LocalEndpoint.Port)
-			&& (Socket->TrafficItem->SocketTuple.Protocol != EProtocol::ICMP
-				&& Socket->TrafficItem->SocketTuple.Protocol != EProtocol::ICMPv6))
+			&& Socket->TrafficItem->SocketTuple.Protocol != EProtocol::ICMP
+			&& Socket->TrafficItem->SocketTuple.Protocol != EProtocol::ICMPv6)
 		{
 			spdlog::debug("Removing socket because its port is no longer in use");
 			return true;

--- a/Source/Daemon/Data/SystemMap.cpp
+++ b/Source/Daemon/Data/SystemMap.cpp
@@ -344,11 +344,11 @@ WSystemMap::WSystemMap()
 		SystemItem->HostName = HostName;
 	}
 	RegisterDefaultFilters();
-	// Periodically check /proc/ for any socket info
-	WTimerManager::GetInstance().AddTimer(5, [this] {
-		std::scoped_lock Lock(DataMutex);
-		SocketStateParser.ParseData();
-	});
+	// Periodically check /proc/ for any socket info (I don't think we need this)
+	// WTimerManager::GetInstance().AddTimer(5, [this] {
+	// 	std::scoped_lock Lock(DataMutex);
+	// 	SocketStateParser.ParseData();
+	// });
 }
 
 static std::string NormalizeAppImagePaths(std::string const& path)

--- a/Source/Daemon/Data/SystemMap.hpp
+++ b/Source/Daemon/Data/SystemMap.hpp
@@ -59,6 +59,10 @@ class WSystemMap : public TSingleton<WSystemMap>, public IMemoryTrackable
 
 	void DoPacketParsing(WSocketEvent const& Event, std::shared_ptr<WSocketCounter> const& SockCounter);
 
+	std::shared_ptr<WSocketCounter> MapSocketFromTrafficEvent(WSocketEvent const& Event);
+
+	void PushTrafficForSocket(WSocketEvent const& Event, std::shared_ptr<WSocketCounter> const& Socket) const;
+
 	std::shared_ptr<WTupleCounter> GetOrCreateUDPTupleCounter(
 		std::shared_ptr<WSocketCounter> const& SockCounter, WEndpoint const& Endpoint);
 

--- a/Source/Daemon/Data/SystemMap.hpp
+++ b/Source/Daemon/Data/SystemMap.hpp
@@ -20,6 +20,7 @@
 #include "Data/MapUpdate.hpp"
 #include "Data/SocketStateParser.hpp"
 
+static constexpr WSocketCookie kSyntheticCookieBase = static_cast<WSocketCookie>(1) << 63;
 /**
  * Both the client and the daemon need a tree of applications, processes, and sockets
  * but the daemon also needs to maintain global traffic counters and mappings.
@@ -94,10 +95,30 @@ public:
 
 	void PushOutgoingTraffic(WSocketEvent const& Event);
 
-	void MarkSocketForRemoval(WSocketCookie SocketCookie)
+	void MarkSocketForRemoval(WSocketEvent const& Event)
 	{
-		if (auto const It = Sockets.find(SocketCookie); It != Sockets.end())
+
+		if (auto const It = Sockets.find(Event.Cookie); It != Sockets.end())
 		{
+			if (Event.Data.SocketCloseEventData.LocalPort > 0)
+			{
+				// todo: iterating over all sockets is a bit dumb since this really
+				// only affects listen sockets that were opened before the daemon started
+				// but it's probably not too much of an issue
+				for (auto const& Sock : Sockets | std::views::values)
+				{
+					if (Sock->TrafficItem->SocketTuple.LocalEndpoint.Port == Event.Data.SocketCloseEventData.LocalPort)
+					{
+						Sock->MarkForRemoval();
+						Sock->TrafficItem->ConnectionState = ESocketConnectionState::Closed;
+						MapUpdate.MarkItemForRemoval(Sock->TrafficItem->ItemId);
+						Sock->ParentProcess->PushIncomingTraffic(0); // Force state update
+						Sock->ParentProcess->ParentApp->PushOutgoingTraffic(0);
+						TrafficCounter.PushIncomingTraffic(0);
+						break;
+					}
+				}
+			}
 			It->second->MarkForRemoval();
 			It->second->TrafficItem->ConnectionState = ESocketConnectionState::Closed;
 			MapUpdate.MarkItemForRemoval(It->second->TrafficItem->ItemId);

--- a/Source/Daemon/EBPF/EbpfObj.cpp
+++ b/Source/Daemon/EBPF/EbpfObj.cpp
@@ -151,9 +151,10 @@ bool WEbpfObj::CreateAndAttachTcxProgram(bpf_program* Program, int ifboverride)
 	int If = ifboverride > 0 ? ifboverride : static_cast<int>(IfIndex);
 
 	auto* Link = bpf_program__attach_tcx(Program, If, &Opts);
-	if (!Link)
+	if (int const Err = libbpf_get_error(Link); Err != 0)
 	{
-		spdlog::critical("Link attachment for tcx program  failed: {}", WErrnoUtil::StrError());
+		spdlog::critical("Link attachment for tcx program '{}' on ifindex {} failed: {}", bpf_program__name(Program),
+			If, WErrnoUtil::StrError(-Err));
 		return false;
 	}
 	Links.emplace_back(Link, Program);

--- a/Source/Daemon/EBPF/EbpfObj.cpp
+++ b/Source/Daemon/EBPF/EbpfObj.cpp
@@ -7,6 +7,7 @@
 
 #include <fcntl.h>
 #include <bpf/bpf.h>
+#include <bpf/libbpf.h>
 #include <net/if.h>
 #include <sys/vfs.h>
 
@@ -93,9 +94,9 @@ bool WEbpfObj::FindAndAttachPlainProgram(std::string const& ProgName)
 
 	bpf_link* Link = bpf_program__attach(Prog);
 
-	if (!Link)
+	if (int const Err = libbpf_get_error(Link); Err != 0)
 	{
-		spdlog::critical("Link attachment for program '{}' failed: {}", ProgName, WErrnoUtil::StrError());
+		spdlog::critical("Link attachment for program '{}' failed: {}", ProgName, WErrnoUtil::StrError(-Err));
 		return false;
 	}
 

--- a/Source/Daemon/EBPF/WaechterEbpf.cpp
+++ b/Source/Daemon/EBPF/WaechterEbpf.cpp
@@ -226,7 +226,7 @@ void WWaechterEbpf::UpdateData()
 				}
 				break;
 			case NE_SocketClosed:
-				WSystemMap::GetInstance().MarkSocketForRemoval(SocketEvent.Cookie);
+				WSystemMap::GetInstance().MarkSocketForRemoval(SocketEvent);
 				break;
 			default:;
 		}

--- a/Source/Daemon/Net/IPLink.cpp
+++ b/Source/Daemon/Net/IPLink.cpp
@@ -93,6 +93,8 @@ void WIPLink::OnDataReceived(WBuffer const& Buf)
 	WLookupEndpointsResponseMsg Response{};
 	if (!WClientSocket::ReceiveMessage(Buf, Response))
 	{
+		spdlog::error("Failed to deserialize IPLink response (readPos={}, writePos={}, readableSize={})",
+			Buf.GetReadPos(), Buf.GetWritePos(), Buf.GetReadableSize());
 		return;
 	}
 	for (auto const& Lookup : Response.LookupResults)

--- a/Source/Daemon/Net/IPLink.cpp
+++ b/Source/Daemon/Net/IPLink.cpp
@@ -250,7 +250,7 @@ void WIPLink::RemovePidDownloadMark(uint32_t Pid)
 	}
 }
 
-void WIPLink::SendLookupMessage(WLookupEndpointsMsg const& LookupMsg)
+void WIPLink::SendLookupMessage(WLookupEndpointsMsg const& LookupMsg) const
 {
 	if (IpProcSocket)
 	{

--- a/Source/Daemon/Net/IPLink.hpp
+++ b/Source/Daemon/Net/IPLink.hpp
@@ -87,7 +87,7 @@ public:
 			ActiveDownloadLimits.size());
 	}
 
-	void SendLookupMessage(WLookupEndpointsMsg const& LookupMsg);
+	void SendLookupMessage(WLookupEndpointsMsg const& LookupMsg) const;
 
 	WMemoryStat GetMemoryUsage() override;
 };

--- a/Source/Daemon/Net/IPLinkProc/IPLinkProc.cpp
+++ b/Source/Daemon/Net/IPLinkProc/IPLinkProc.cpp
@@ -145,8 +145,9 @@ static bool SetupHtbClass(std::shared_ptr<WSetupHtbClassMsg> const& SetupHtbClas
 	spdlog::info("Setup filter with mark {}", SetupHtbClass->Mark);
 	SYSFMT("tc filter replace dev {} parent 1: protocol ip pref 1 handle 0x{:x} fw classid 1:{}", IfName,
 		SetupHtbClass->Mark, SetupHtbClass->MinorId);
-	SYSFMT("tc filter replace dev {} parent 1: protocol ipv6 pref 1 handle 0x{:x} fw classid 1:{}", IfName,
-		SetupHtbClass->Mark, SetupHtbClass->MinorId);
+	// todo: handle ipv6, it should either be a ipv4 OR ipv6 filter so we have to determine that beforehand
+	// SYSFMT("tc filter replace dev {} parent 1: protocol ipv6 pref 1 handle 0x{:x} fw classid 1:{}", IfName,
+	// 	SetupHtbClass->Mark, SetupHtbClass->MinorId);
 	return true;
 }
 
@@ -158,8 +159,9 @@ static bool RemoveHtbClass(std::shared_ptr<WRemoveHtbClassMsg> const& RemoveHtbC
 
 	SYSFMT2("tc filter delete dev {} parent 1: protocol ip pref 1 handle 0x{:x} fw classid 1:{}", IfName,
 		RemoveHtbClass->Mark, RemoveHtbClass->MinorId);
-	SYSFMT2("tc filter delete dev {} parent 1: protocol ipv6 pref 1 handle 0x{:x} fw classid 1:{}", IfName,
-		RemoveHtbClass->Mark, RemoveHtbClass->MinorId);
+	// todo: handle ipv6, it should either be a ipv4 OR ipv6 filter so we have to determine that beforehand
+	// SYSFMT2("tc filter delete dev {} parent 1: protocol ipv6 pref 1 handle 0x{:x} fw classid 1:{}", IfName,
+	// 	RemoveHtbClass->Mark, RemoveHtbClass->MinorId);
 	SYSFMT("tc class delete dev {} classid 1:{}", IfName, RemoveHtbClass->MinorId);
 	return true;
 }

--- a/Source/Daemon/Net/IPLinkProc/IPLinkProc.cpp
+++ b/Source/Daemon/Net/IPLinkProc/IPLinkProc.cpp
@@ -311,7 +311,7 @@ int main(int Argc, char** Argv)
 		spdlog::set_pattern("[%^%l%$] [tc] %v");
 	}
 
-	if (Argc < 4)
+	if (Argc < 5)
 	{
 		spdlog::error("Usage: waechter-iplink [socket path] [ifb dev] [ingress interface] [main interface]");
 		return -1;

--- a/Source/Daemon/Net/IPLinkProc/IPLinkProc.cpp
+++ b/Source/Daemon/Net/IPLinkProc/IPLinkProc.cpp
@@ -212,12 +212,12 @@ WLookupEndpointsResponseMsg LookupEndpoints(std::shared_ptr<WLookupEndpointsMsg>
 	{
 		if (auto It = UsedEndpoints.find(Endpoint); It != UsedEndpoints.end())
 		{
-			spdlog::info("Looking up {} -> {}", Endpoint.ToString(), It->second);
+			spdlog::debug("Looking up {} -> {}", Endpoint.ToString(), It->second);
 			Response.LookupResults.emplace_back(Endpoint, It->second);
 		}
 		else
 		{
-			spdlog::info("Looking up {} -> 0", Endpoint.ToString());
+			spdlog::debug("Looking up {} -> 0", Endpoint.ToString());
 			Response.LookupResults.emplace_back(Endpoint, 0);
 		}
 	}

--- a/Source/Daemon/Net/IPLinkProc/IPLinkProc.cpp
+++ b/Source/Daemon/Net/IPLinkProc/IPLinkProc.cpp
@@ -145,6 +145,8 @@ static bool SetupHtbClass(std::shared_ptr<WSetupHtbClassMsg> const& SetupHtbClas
 	spdlog::info("Setup filter with mark {}", SetupHtbClass->Mark);
 	SYSFMT("tc filter replace dev {} parent 1: protocol ip pref 1 handle 0x{:x} fw classid 1:{}", IfName,
 		SetupHtbClass->Mark, SetupHtbClass->MinorId);
+	SYSFMT("tc filter replace dev {} parent 1: protocol ipv6 pref 1 handle 0x{:x} fw classid 1:{}", IfName,
+		SetupHtbClass->Mark, SetupHtbClass->MinorId);
 	return true;
 }
 
@@ -155,6 +157,8 @@ static bool RemoveHtbClass(std::shared_ptr<WRemoveHtbClassMsg> const& RemoveHtbC
 		RemoveHtbClass->Mark);
 
 	SYSFMT2("tc filter delete dev {} parent 1: protocol ip pref 1 handle 0x{:x} fw classid 1:{}", IfName,
+		RemoveHtbClass->Mark, RemoveHtbClass->MinorId);
+	SYSFMT2("tc filter delete dev {} parent 1: protocol ipv6 pref 1 handle 0x{:x} fw classid 1:{}", IfName,
 		RemoveHtbClass->Mark, RemoveHtbClass->MinorId);
 	SYSFMT("tc class delete dev {} classid 1:{}", IfName, RemoveHtbClass->MinorId);
 	return true;

--- a/Source/Daemon/Rules/RuleManager.cpp
+++ b/Source/Daemon/Rules/RuleManager.cpp
@@ -280,7 +280,7 @@ void WRuleManager::HandleRuleChange(WBuffer const& Buf)
 		return;
 	}
 
-	spdlog::info("Rule Change: {}", Update.Rules.ToString());
+	spdlog::info("Rule Change for {}: {}", Update.TrafficItemId, Update.Rules.ToString());
 
 	std::lock_guard Lock(Mutex);
 
@@ -295,10 +295,9 @@ void WRuleManager::HandleRuleChange(WBuffer const& Buf)
 
 	if (Update.Rules.DownloadLimit == 0)
 	{
-		auto SocketItem = std::dynamic_pointer_cast<WSocketItem>(Item);
-		if (SocketItem)
+		if (auto const SocketItem = std::dynamic_pointer_cast<WSocketItem>(Item))
 		{
-			WIPLink::GetInstance().RemoveIngressPortRouting(SocketItem->SocketTuple.LocalEndpoint.Port);
+			WIPLink::RemoveIngressPortRouting(SocketItem->SocketTuple.LocalEndpoint.Port);
 		}
 		WIPLink::GetInstance().RemoveDownloadLimit(Update.TrafficItemId);
 	}
@@ -328,7 +327,7 @@ void WRuleManager::HandleRuleChange(WBuffer const& Buf)
 		{
 			ApplicationRules[Update.TrafficItemId] = Update.Rules;
 			// Set PID download marks for all processes under this application
-			auto AppItemCast = std::dynamic_pointer_cast<WApplicationItem>(Item);
+			auto const AppItemCast = std::dynamic_pointer_cast<WApplicationItem>(Item);
 			if (AppItemCast && Update.Rules.DownloadMark != 0)
 			{
 				for (auto const& Pid : AppItemCast->Processes | std::views::keys)

--- a/Source/Daemon/Rules/RuleManager.cpp
+++ b/Source/Daemon/Rules/RuleManager.cpp
@@ -208,19 +208,17 @@ void WRuleManager::SyncRules()
 				static_cast<int>(SockRules.Rules.UploadSwitch), static_cast<int>(SockRules.Rules.DownloadSwitch));
 			SockRules.bDirty = false;
 		}
-		auto TrafficItem = WSystemMap::GetInstance().GetTrafficItemById(SockRules.SocketId);
-		if (TrafficItem)
+		if (auto TrafficItem = WSystemMap::GetInstance().GetTrafficItemById(SockRules.SocketId))
 		{
-			auto SocketItem = std::dynamic_pointer_cast<WSocketItem>(TrafficItem);
-			if (SocketItem)
+			if (auto const SocketItem = std::dynamic_pointer_cast<WSocketItem>(TrafficItem))
 			{
 				if (SockRules.Rules.DownloadMark == 0)
 				{
-					WIPLink::GetInstance().RemoveIngressPortRouting(SocketItem->SocketTuple.LocalEndpoint.Port);
+					WIPLink::RemoveIngressPortRouting(SocketItem->SocketTuple.LocalEndpoint.Port);
 				}
 				else if (SocketItem->SocketTuple.LocalEndpoint.Port != 0)
 				{
-					WIPLink::GetInstance().SetupIngressPortRouting(
+					WIPLink::SetupIngressPortRouting(
 						SockRules.SocketId, SockRules.Rules.DownloadMark, SocketItem->SocketTuple.LocalEndpoint.Port);
 				}
 			}

--- a/Source/EBPF/EBPFConnect.h
+++ b/Source/EBPF/EBPFConnect.h
@@ -57,8 +57,10 @@ int BPF_PROG(on_tcp_set_state, struct sock* Sk, int Newstate)
 	{
 		struct WSocketEvent* Event = MakeSocketEvent(bpf_get_socket_cookie(Sk), NE_SocketClosed);
 
+		u16 Lport = BPF_CORE_READ(Sk, __sk_common.skc_num);
 		if (Event)
 		{
+			Event->Data.SocketCloseEventData.LocalPort = Lport;
 			bpf_ringbuf_submit(Event, 0);
 		}
 
@@ -67,7 +69,6 @@ int BPF_PROG(on_tcp_set_state, struct sock* Sk, int Newstate)
 		// so we must NOT delete the mapping when an accepted connection closes.
 		if (Oldstate == TCP_LISTEN)
 		{
-			u16 Lport = BPF_CORE_READ(Sk, __sk_common.skc_num);
 			if (Lport != 0)
 			{
 				bpf_map_delete_elem(&port_to_pid, &Lport);

--- a/Source/EBPF/EBPFTraffic.h
+++ b/Source/EBPF/EBPFTraffic.h
@@ -252,7 +252,6 @@ int ifb_cls_egress(struct __sk_buff* skb)
 
 	if (Mark && *Mark != 0)
 	{
-		bpf_printk("Setting mark for port %d to %d (port-based)\n", DstPort, *Mark);
 		skb->mark = *Mark;
 	}
 	else
@@ -265,7 +264,6 @@ int ifb_cls_egress(struct __sk_buff* skb)
 			__u32* PidMark = bpf_map_lookup_elem(&pid_download_marks, Pid);
 			if (PidMark && *PidMark != 0)
 			{
-				bpf_printk("Setting mark for port %d to %d (PID %d fallback)\n", DstPort, *PidMark, *Pid);
 				skb->mark = *PidMark;
 			}
 		}

--- a/Source/Gui/Windows/TrafficTree.cpp
+++ b/Source/Gui/Windows/TrafficTree.cpp
@@ -377,9 +377,9 @@ void WTrafficTree::UpdateFromBuffer(WBuffer const& Buffer)
 			{
 				SocketItem->ConnectionState = StateChange.NewState;
 				SocketItem->SocketType = StateChange.SocketType;
-				if (StateChange.SocketTuple.has_value())
+				if (StateChange.SocketTuple)
 				{
-					SocketItem->SocketTuple = StateChange.SocketTuple.value();
+					SocketItem->SocketTuple = *StateChange.SocketTuple.get();
 				}
 			}
 		}

--- a/Source/Gui/Windows/TrafficTree.cpp
+++ b/Source/Gui/Windows/TrafficTree.cpp
@@ -170,7 +170,16 @@ bool WTrafficTree::RenderItem(WRenderItemArgs const& Args)
 	if (ImGui::IsItemHovered())
 	{
 		ImGui::BeginTooltip();
-		ImGui::Text("ID: %llu", Args.Item->ItemId);
+		if (Args.Item->GetType() == TI_Socket)
+		{
+			auto const Socket = std::static_pointer_cast<WSocketItem>(Args.Item);
+			ImGui::Text("ID: %llu, Cookie: %lu", Args.Item->ItemId, Socket->Cookie);
+		}
+		else
+		{
+			ImGui::Text("ID: %llu", Args.Item->ItemId);
+		}
+
 		ImGui::EndTooltip();
 	}
 #endif

--- a/Source/Gui/Windows/TrafficTree.cpp
+++ b/Source/Gui/Windows/TrafficTree.cpp
@@ -242,6 +242,10 @@ void WTrafficTree::LoadFromBuffer(WBuffer const& Buffer)
 			for (auto const& Sock : Proc->Sockets | std::views::values)
 			{
 				TrafficItems[Sock->ItemId] = Sock;
+				for (auto const& UDPTuple : Sock->UDPPerConnectionTraffic | std::views::values)
+				{
+					TrafficItems[UDPTuple->ItemId] = UDPTuple;
+				}
 			}
 		}
 	}

--- a/Source/Util/ClientSocket.cpp
+++ b/Source/Util/ClientSocket.cpp
@@ -7,6 +7,8 @@
 
 #include "spdlog/spdlog.h"
 
+#include <netinet/in.h>
+
 void WClientSocket::ListenThreadFunction()
 {
 	WBuffer RecvBuf;
@@ -16,8 +18,9 @@ void WClientSocket::ListenThreadFunction()
 		{
 			continue;
 		}
+		spdlog::info("Received framed message of size {} bytes", RecvBuf.GetWritePos());
 		OnData(RecvBuf);
-		RecvBuf.Compact();
+		RecvBuf.Reset();
 	}
 	bListenThreadRunning = false;
 }
@@ -55,7 +58,6 @@ void WClientSocket::Close()
 	{
 		OnClosed();
 	}
-	IncomingBuffer.Reset();
 }
 
 bool WClientSocket::Connect()
@@ -127,6 +129,7 @@ bool WClientSocket::SendFramed(void const* Data, size_t Size)
 
 bool WClientSocket::SendFramed(std::string const& Payload)
 {
+	spdlog::info("Sending {}", Payload.size());
 	return SendFramed(Payload.data(), Payload.size());
 }
 
@@ -153,63 +156,36 @@ ssize_t WClientSocket::ReceiveRaw(void* Buffer, size_t Capacity)
 
 bool WClientSocket::ReceiveFramed(WBuffer& OutputBuffer)
 {
+
 	if (!IsConnected())
 	{
 		return false;
 	}
+	static char   IoBuf[4096];
+	ssize_t const BytesRead = ReceiveRaw(IoBuf, sizeof(IoBuf));
 
-	// Helper lambda to try extracting a frame from IncomingBuffer.
-	// Returns true if a complete frame was extracted.
-	auto TryExtractFrame = [&]() -> bool {
-		if (IncomingBuffer.GetReadableSize() < sizeof(uint32_t))
+	// Accumulate data (handle fragmented messages)
+	IncomingBuffer.insert(IncomingBuffer.end(), IoBuf, IoBuf + std::max<ssize_t>(0, BytesRead));
+
+	// Try to extract complete frames
+	while (IncomingBuffer.size() >= sizeof(uint32_t))
+	{
+		uint32_t FrameLength = 0;
+		std::memcpy(&FrameLength, IncomingBuffer.data(), sizeof(uint32_t));
+
+		if (IncomingBuffer.size() < sizeof(uint32_t) + FrameLength)
 		{
+			// Not enough data for complete frame
 			return false;
 		}
 
-		auto const ReadableData = IncomingBuffer.GetReadableData();
-		uint32_t FrameLen = 0;
-		std::memcpy(&FrameLen, ReadableData.data(), sizeof(uint32_t));
+		// Extract frame data (skip length prefix)
+		OutputBuffer.Write(std::span<char const>(IncomingBuffer.data() + sizeof(uint32_t), FrameLength));
 
-		// Do we have the full body?
-		if (IncomingBuffer.GetReadableSize() < sizeof(uint32_t) + FrameLen)
-		{
-			return false;
-		}
-
-		// We have a full frame. Extract it.
-		IncomingBuffer.Consume(sizeof(uint32_t)); // Skip header
-
-		OutputBuffer.Reset();
-		OutputBuffer.Write(IncomingBuffer.GetReadableData().first(FrameLen));
-		IncomingBuffer.Consume(FrameLen);
-
-		if (IncomingBuffer.GetReadPos() > 2048)
-		{
-			IncomingBuffer.Compact();
-		}
-
-		return true;
-	};
-
-	// 1. First check if we already have a complete frame buffered from a previous read.
-	//    This avoids blocking on recv() when we already have data to process.
-	if (TryExtractFrame())
-	{
+		// Remove processed data from buffer
+		IncomingBuffer.erase(
+			IncomingBuffer.begin(), IncomingBuffer.begin() + static_cast<ptrdiff_t>(sizeof(uint32_t) + FrameLength));
 		return true;
 	}
-
-	// 2. No complete frame buffered, so read more data from the network.
-	//    This is a blocking call.
-	char    IoBuf[4096];
-	ssize_t BytesRead = ReceiveRaw(IoBuf, sizeof(IoBuf));
-
-	if (BytesRead > 0)
-	{
-		IncomingBuffer.Write(std::span{ IoBuf, static_cast<std::size_t>(BytesRead) });
-	}
-	// If BytesRead < 0 (error) or == 0 (closed), IsConnected() will likely be false now,
-	// but we might still have data in IncomingBuffer to process, so we continue.
-
-	// 3. Try to extract a frame now
-	return TryExtractFrame();
+	return false;
 }

--- a/Source/Util/ClientSocket.cpp
+++ b/Source/Util/ClientSocket.cpp
@@ -18,7 +18,6 @@ void WClientSocket::ListenThreadFunction()
 		{
 			continue;
 		}
-		spdlog::info("Received framed message of size {} bytes", RecvBuf.GetWritePos());
 		OnData(RecvBuf);
 		RecvBuf.Reset();
 	}
@@ -129,7 +128,6 @@ bool WClientSocket::SendFramed(void const* Data, size_t Size)
 
 bool WClientSocket::SendFramed(std::string const& Payload)
 {
-	spdlog::info("Sending {}", Payload.size());
 	return SendFramed(Payload.data(), Payload.size());
 }
 

--- a/Source/Util/Data/SocketItem.hpp
+++ b/Source/Util/Data/SocketItem.hpp
@@ -64,4 +64,10 @@ struct WSocketItem : ITrafficItem
 	}
 
 	[[nodiscard]] ETrafficItemType GetType() const override { return TI_Socket; }
+
+	bool operator==(WSocketItem const& Other) const
+	{
+		return SocketTuple == Other.SocketTuple && SocketType == Other.SocketType
+			&& ConnectionState == Other.ConnectionState && Cookie == Other.Cookie;
+	}
 };

--- a/Source/Util/Data/SocketStateParser.cpp
+++ b/Source/Util/Data/SocketStateParser.cpp
@@ -31,13 +31,18 @@ static bool MatchesLocalEndpoint(WEndpoint const& ParsedEndpoint, WEndpoint cons
 	return ParsedEndpoint.Address.IsZero() && ParsedEndpoint.Address.Family == TargetEndpoint.Address.Family;
 }
 
+static bool MatchesRemoteEndpoint(WEndpoint const& ParsedEndpoint, WEndpoint const& TargetEndpoint)
+{
+	return ParsedEndpoint == TargetEndpoint;
+}
+
 WSocketStateParser::WSocketStateParser()
 {
 	ParseData();
 }
 
 ESocketType::Type WSocketStateParser::DetermineSocketType(
-	WEndpoint const& LocalEndpoint, EProtocol::Type Protocol) const
+	WEndpoint const& LocalEndpoint, EProtocol::Type Protocol, WEndpoint const* RemoteEndpoint) const
 {
 	std::scoped_lock Lock(Mutex);
 	if (Protocol == EProtocol::TCP)
@@ -50,7 +55,7 @@ ESocketType::Type WSocketStateParser::DetermineSocketType(
 
 			while (std::getline(File, Line))
 			{
-				if (auto Result = ParseTcpLine(Line, LocalEndpoint); Result.has_value())
+				if (auto Result = ParseTcpLine(Line, LocalEndpoint, RemoteEndpoint); Result.has_value())
 				{
 					return Result.value();
 				}
@@ -65,7 +70,7 @@ ESocketType::Type WSocketStateParser::DetermineSocketType(
 
 			while (std::getline(File, Line))
 			{
-				auto Result = ParseTcpLine(Line, LocalEndpoint);
+				auto Result = ParseTcpLine(Line, LocalEndpoint, RemoteEndpoint);
 				if (Result.has_value())
 				{
 					return Result.value();
@@ -83,7 +88,7 @@ ESocketType::Type WSocketStateParser::DetermineSocketType(
 
 			while (std::getline(File, Line))
 			{
-				if (auto Result = ParseUdpLine(Line, LocalEndpoint); Result.has_value())
+				if (auto Result = ParseUdpLine(Line, LocalEndpoint, RemoteEndpoint); Result.has_value())
 				{
 					return Result.value();
 				}
@@ -98,7 +103,7 @@ ESocketType::Type WSocketStateParser::DetermineSocketType(
 
 			while (std::getline(File, Line))
 			{
-				if (auto Result = ParseUdpLine(Line, LocalEndpoint); Result.has_value())
+				if (auto Result = ParseUdpLine(Line, LocalEndpoint, RemoteEndpoint); Result.has_value())
 				{
 					return Result.value();
 				}
@@ -318,7 +323,7 @@ void WSocketStateParser::ParseUdpFile(
 }
 
 std::optional<ESocketType::Type> WSocketStateParser::ParseTcpLine(
-	std::string const& Line, WEndpoint const& TargetEndpoint) const
+	std::string const& Line, WEndpoint const& TargetEndpoint, WEndpoint const* RemoteEndpoint) const
 {
 	std::istringstream Iss(Line);
 	std::string        Slot, LocalAddrStr, RemAddrStr;
@@ -338,6 +343,25 @@ std::optional<ESocketType::Type> WSocketStateParser::ParseTcpLine(
 	if (!MatchesLocalEndpoint(WEndpoint{ LocalAddr, LocalPort }, TargetEndpoint))
 	{
 		return std::nullopt;
+	}
+
+	if (RemoteEndpoint)
+	{
+		WIPAddress RemoteAddr;
+		uint16_t   RemotePort;
+		if (bool const bIsIPv6 = LocalAddrStr.find(':') != LocalAddrStr.rfind(':');
+			!ParseAddressPort(RemAddrStr, RemoteAddr, RemotePort, bIsIPv6))
+		{
+			return std::nullopt;
+		}
+
+		if (!RemoteEndpoint->Address.IsZero() || RemoteEndpoint->Port != 0)
+		{
+			if (!MatchesRemoteEndpoint(WEndpoint{ RemoteAddr, RemotePort }, *RemoteEndpoint))
+			{
+				return std::nullopt;
+			}
+		}
 	}
 
 	if (State == TCP_LISTEN)
@@ -365,7 +389,7 @@ std::optional<ESocketType::Type> WSocketStateParser::ParseTcpLine(
 }
 
 std::optional<ESocketType::Type> WSocketStateParser::ParseUdpLine(
-	std::string const& Line, WEndpoint const& TargetEndpoint) const
+	std::string const& Line, WEndpoint const& TargetEndpoint, WEndpoint const* RemoteEndpoint) const
 {
 	std::istringstream Iss(Line);
 	std::string        Slot, LocalAddrStr, RemAddrStr;
@@ -390,6 +414,12 @@ std::optional<ESocketType::Type> WSocketStateParser::ParseUdpLine(
 	uint16_t   RemPort;
 
 	if (!ParseAddressPort(RemAddrStr, RemAddr, RemPort, bIsIPv6))
+	{
+		return std::nullopt;
+	}
+
+	if (RemoteEndpoint && (!RemoteEndpoint->Address.IsZero() || RemoteEndpoint->Port != 0)
+		&& !MatchesRemoteEndpoint(WEndpoint{ RemAddr, RemPort }, *RemoteEndpoint))
 	{
 		return std::nullopt;
 	}

--- a/Source/Util/Data/SocketStateParser.cpp
+++ b/Source/Util/Data/SocketStateParser.cpp
@@ -16,6 +16,21 @@ constexpr uint32_t TCP_LISTEN = 0x0A;
 
 constexpr uint16_t EPHEMERAL_PORT_START = 32768;
 
+static bool MatchesLocalEndpoint(WEndpoint const& ParsedEndpoint, WEndpoint const& TargetEndpoint)
+{
+	if (ParsedEndpoint.Port != TargetEndpoint.Port)
+	{
+		return false;
+	}
+
+	if (ParsedEndpoint.Address == TargetEndpoint.Address)
+	{
+		return true;
+	}
+
+	return ParsedEndpoint.Address.IsZero() && ParsedEndpoint.Address.Family == TargetEndpoint.Address.Family;
+}
+
 WSocketStateParser::WSocketStateParser()
 {
 	ParseData();
@@ -320,7 +335,7 @@ std::optional<ESocketType::Type> WSocketStateParser::ParseTcpLine(
 		return std::nullopt;
 	}
 
-	if (LocalPort != TargetEndpoint.Port || TargetEndpoint.Address != LocalAddr)
+	if (!MatchesLocalEndpoint(WEndpoint{ LocalAddr, LocalPort }, TargetEndpoint))
 	{
 		return std::nullopt;
 	}
@@ -366,7 +381,7 @@ std::optional<ESocketType::Type> WSocketStateParser::ParseUdpLine(
 		return std::nullopt;
 	}
 
-	if (LocalPort != TargetEndpoint.Port || TargetEndpoint.Address != LocalAddr)
+	if (!MatchesLocalEndpoint(WEndpoint{ LocalAddr, LocalPort }, TargetEndpoint))
 	{
 		return std::nullopt;
 	}
@@ -394,7 +409,7 @@ std::optional<ESocketType::Type> WSocketStateParser::ParseUdpLine(
 }
 
 bool WSocketStateParser::ParseAddressPort(
-	std::string const& AddrPortStr, WIPAddress& OutAddr, uint16_t& OutPort, bool bIsIPv6)
+	std::string const& AddrPortStr, WIPAddress& OutAddr, uint16_t& OutPort, bool const bIsIPv6)
 {
 	size_t const ColonPos = AddrPortStr.find(':');
 	if (ColonPos == std::string::npos)

--- a/Source/Util/Data/SocketStateParser.hpp
+++ b/Source/Util/Data/SocketStateParser.hpp
@@ -55,7 +55,20 @@ public:
 	{
 		std::scoped_lock Lock(Mutex);
 		if (auto It = KnownUsedEndpoints.find(Endpoint); It != KnownUsedEndpoints.end())
+		{
 			return It->second;
+		}
+
+		if (!Endpoint.Address.IsZero())
+		{
+			WEndpoint WildcardEndpoint = Endpoint;
+			WildcardEndpoint.Address = {};
+			WildcardEndpoint.Address.Family = Endpoint.Address.Family;
+			if (auto It = KnownUsedEndpoints.find(WildcardEndpoint); It != KnownUsedEndpoints.end())
+			{
+				return It->second;
+			}
+		}
 		return -1;
 	}
 

--- a/Source/Util/Data/SocketStateParser.hpp
+++ b/Source/Util/Data/SocketStateParser.hpp
@@ -35,11 +35,12 @@ class WSocketStateParser
 public:
 	WSocketStateParser();
 
-	[[nodiscard]] ESocketType::Type DetermineSocketType(WEndpoint const& LocalEndpoint, EProtocol::Type Protocol) const;
+	[[nodiscard]] ESocketType::Type DetermineSocketType(
+		WEndpoint const& LocalEndpoint, EProtocol::Type Protocol, WEndpoint const* RemoteEndpoint = nullptr) const;
 
 	void ParseData() const;
 
-	bool IsUsedPort(uint16_t Port)
+	bool IsUsedPort(uint16_t const Port) const
 	{
 		if (Port == 0)
 		{
@@ -54,7 +55,7 @@ public:
 	WProcessId GetEndpointPID(WEndpoint const& Endpoint) const
 	{
 		std::scoped_lock Lock(Mutex);
-		if (auto It = KnownUsedEndpoints.find(Endpoint); It != KnownUsedEndpoints.end())
+		if (auto const It = KnownUsedEndpoints.find(Endpoint); It != KnownUsedEndpoints.end())
 		{
 			return It->second;
 		}
@@ -84,10 +85,12 @@ private:
 	void ParseUdpFile(std::string const& FilePath, std::unordered_map<uint64_t, WProcessId> const& InodePidMap) const;
 
 	// Parse line from /proc/net/tcp or /proc/net/tcp6
-	std::optional<ESocketType::Type> ParseTcpLine(std::string const& Line, WEndpoint const& TargetEndpoint) const;
+	std::optional<ESocketType::Type> ParseTcpLine(
+		std::string const& Line, WEndpoint const& TargetEndpoint, WEndpoint const* RemoteEndpoint) const;
 
 	// Parse line from /proc/net/udp or /proc/net/udp6
-	std::optional<ESocketType::Type> ParseUdpLine(std::string const& Line, WEndpoint const& TargetEndpoint) const;
+	std::optional<ESocketType::Type> ParseUdpLine(
+		std::string const& Line, WEndpoint const& TargetEndpoint, WEndpoint const* RemoteEndpoint) const;
 
 	// parse hex address:port format
 	static bool ParseAddressPort(std::string const& AddrPortStr, WIPAddress& OutAddr, uint16_t& OutPort, bool bIsIPv6);

--- a/Source/Util/Data/TrafficTreeUpdate.hpp
+++ b/Source/Util/Data/TrafficTreeUpdate.hpp
@@ -72,10 +72,10 @@ struct WTrafficTreeTupleAddition
 
 struct WTrafficTreeSocketStateChange
 {
-	WTrafficItemId              ItemId{};
-	ESocketConnectionState      NewState{};
-	uint8_t                     SocketType{};
-	std::optional<WSocketTuple> SocketTuple{};
+	WTrafficItemId                ItemId{};
+	ESocketConnectionState        NewState{};
+	uint8_t                       SocketType{};
+	std::shared_ptr<WSocketTuple> SocketTuple{};
 
 	template <class Archive>
 	void serialize(Archive& archive)

--- a/Source/Util/EBPFCommon.h
+++ b/Source/Util/EBPFCommon.h
@@ -142,6 +142,11 @@ struct WSocketAcceptEventData
 	};
 };
 
+struct WSocketCloseEventData
+{
+	__u32 LocalPort;
+};
+
 struct WSocketEventData
 {
 	union
@@ -152,6 +157,7 @@ struct WSocketEventData
 		struct WSocketTCPEstablishedEventData TCPSocketEstablishedEventData;
 		struct WSocketBindEventData           SocketBindEventData;
 		struct WSocketAcceptEventData         SocketAcceptEventData;
+		struct WSocketCloseEventData          SocketCloseEventData;
 	};
 };
 

--- a/Source/Util/ErrnoUtil.hpp
+++ b/Source/Util/ErrnoUtil.hpp
@@ -11,5 +11,15 @@
 class WErrnoUtil
 {
 public:
-	static std::string StrError() { return std::string(strerror(errno)); }
+	static std::string StrError(int const Err = 0)
+	{
+		if (Err == 0)
+		{
+			return std::string(strerror(errno));
+		}
+		else
+		{
+			return std::string(strerror(Err));
+		}
+	}
 };

--- a/Source/Util/IPAddress.hpp
+++ b/Source/Util/IPAddress.hpp
@@ -370,6 +370,12 @@ struct WSocketTuple
 		return LocalEndpoint.ToString() + " -> " + RemoteEndpoint.ToString() + " (" + EProtocol::ToString(Protocol)
 			+ ")";
 	}
+
+	bool operator==(WSocketTuple const& Other) const
+	{
+		return LocalEndpoint == Other.LocalEndpoint && RemoteEndpoint == Other.RemoteEndpoint
+			&& Protocol == Other.Protocol;
+	}
 };
 
 struct ByteArray16Hash

--- a/Source/Util/Socket.hpp
+++ b/Source/Util/Socket.hpp
@@ -39,7 +39,7 @@ public:
 class WClientSocket : public WSocket
 {
 	// Stores raw bytes read from the socket until a full frame is assembled
-	WBuffer           IncomingBuffer{ 4096 };
+	std::string       IncomingBuffer{};
 	bool              bIsConnected{ false };
 	std::thread       ListenerThread;
 	std::atomic<bool> bListenThreadRunning{ false };


### PR DESCRIPTION
Various fixes for the system map. Fixes missing sockets on first startup. Issues left to address:
- Initially mapped sockets for steam sometimes show as listen/connect + tcp, in actuality those sockets are connect TCP sockets

Things to test:
- [x] Whether sockets that were opened before the daemon started are correctly removed when they close
- [x] Limits not working anymore