### PR TITLE
Implement system rules

### DIFF
--- a/Meta/I18n/de_DE.json
+++ b/Meta/I18n/de_DE.json
@@ -45,7 +45,8 @@
     "search.apps": "Anwendungen durchsuchen",
     "connected": "Mit Daemon verbunden",
     "not_connected": "Nicht mit Daemon verbunden",
-    "process": "Prozess"
+    "process": "Prozess",
+    "lockout_warning_text": "Sie sind dabei, die Regeln entweder für das gesamte System, den Daemon oder den Client zu ändern, während Sie über eine WebSocket-Verbindung verbunden sind. Wenn Sie in diesem Fall Verbindungen blockieren oder stark drosseln, werden Sie vom Daemon ausgesperrt."
   },
   "generic": {
     "ok": "OK",

--- a/Meta/I18n/en_US.json
+++ b/Meta/I18n/en_US.json
@@ -21,6 +21,7 @@
       "accept": "Accept",
       "invalid": "Invalid"
     },
+    "lockout_warning_text": "You are about to change the rules for either the entire system, the daemon or the client while being connected via a WebSocket. If you block or severely throttle connections in this case you will be locked out from the daemon.",
     "proto.unknown": "Unknown",
     "hostname": "Hostname",
     "uptime": "Uptime",

--- a/Meta/Scripts/Binary.py
+++ b/Meta/Scripts/Binary.py
@@ -1,3 +1,6 @@
+import json
+
+
 def bytes_to_cpp_array(data: bytes) -> str:
 
     return ", ".join(f"0x{b:02X}" for b in data)
@@ -26,6 +29,59 @@ def output_to_cpp(arrays: list[str], defs: list[str], output_path: str):
 """ + "\n".join(defs)
     with open("../../Source/Gui/" + output_path + ".hpp", "w") as f:
         f.write(header_code)
+
+
+with open("../I18n/en_US.json") as f:
+    en = json.load(f)
+
+
+def compare_structure(a, b, path=""):
+    # Types must match
+    if type(a) != type(b):
+        return [f"{path}: type mismatch ({type(a).__name__} != {type(b).__name__})"]
+
+    # Dictionaries
+    if isinstance(a, dict):
+        errors = []
+
+        missing = a.keys() - b.keys()
+        extra = b.keys() - a.keys()
+
+        for key in sorted(missing):
+            errors.append(f"{path}/{key}: missing")
+
+        for key in sorted(extra):
+            errors.append(f"{path}/{key}: extra")
+
+        for key in sorted(a.keys() & b.keys()):
+            errors.extend(compare_structure(a[key], b[key], f"{path}/{key}"))
+
+        return errors
+
+    # Lists
+    if isinstance(a, list):
+        errors = []
+
+        if len(a) != len(b):
+            errors.append(f"{path}: list length differs ({len(a)} != {len(b)})")
+            return errors
+
+        for i, (x, y) in enumerate(zip(a, b)):
+            errors.extend(compare_structure(x, y, f"{path}[{i}]"))
+
+        return errors
+
+    return []
+
+
+def check_lang_file(f):
+    with open(f) as lang_file:
+        lang_data = json.load(lang_file)
+        errors = compare_structure(en, lang_data)
+        if errors:
+            print(f"Errors in {f}:")
+            for error in errors:
+                print(f"  {error}")
 
 if __name__ == "__main__":
 
@@ -64,6 +120,9 @@ if __name__ == "__main__":
     em = []
     for i in input_files:
         f, n = i
+
+        if f.endswith(".json") and "I18n" in f and not f.endswith("en_US.json"):
+            check_lang_file(f)
         code, embed = generate_embed(f, n)
         co.append(code)
         em.append(embed)

--- a/Source/Daemon/Data/SystemMap.cpp
+++ b/Source/Daemon/Data/SystemMap.cpp
@@ -6,7 +6,6 @@
 #include "SystemMap.hpp"
 
 #include <array>
-#include <cstdlib>
 #include <ranges>
 #include <regex>
 #include <utility>
@@ -531,6 +530,7 @@ void WSystemMap::ReparentAcceptedSocket(std::shared_ptr<WSocketCounter> const& S
 
 WSystemMap::WSystemMap()
 {
+	TrafficItems[SystemItem->ItemId] = SystemItem;
 	auto const HostName = WFilesystem::ReadProc("/proc/sys/kernel/hostname");
 	if (!HostName.empty())
 	{

--- a/Source/Daemon/Net/IPLink.cpp
+++ b/Source/Daemon/Net/IPLink.cpp
@@ -31,7 +31,7 @@
 
 // Helper: launch a detached process (double-fork). The child is forked while this process
 // still has root privileges, so the launched process will inherit root (UID=0) and keep it
-// independently of this process dropping privileges later.
+// independently of this process, dropping privileges later.
 static bool LaunchDetachedProcess(std::string const& cmd)
 {
 	return system(fmt::format("{} &", cmd).c_str()) == 0;
@@ -39,9 +39,9 @@ static bool LaunchDetachedProcess(std::string const& cmd)
 
 constexpr int kIngressPortFilterPriority = 1;
 
-WBandwidthLimit::WBandwidthLimit(
-	uint32_t Mark_, uint16_t MinorId_, WBytesPerSecond RateLimit_, ELimitDirection Direction_)
-	: Direction(Direction_), Mark(Mark_), MinorId(MinorId_), RateLimit(RateLimit_)
+WBandwidthLimit::WBandwidthLimit(uint32_t const Mark_, uint16_t const MinorId_, WBytesPerSecond const RateLimit_,
+	ELimitDirection const Direction_, bool const bIsRoot_)
+	: Direction(Direction_), Mark(Mark_), MinorId(MinorId_), bIsRoot(bIsRoot_), RateLimit(RateLimit_)
 {
 }
 
@@ -49,8 +49,8 @@ WBandwidthLimit::~WBandwidthLimit()
 {
 	spdlog::debug("HTB limit class being removed: classid=1:{}, rate={} B/s", MinorId, RateLimit);
 	// clean up tc classes and filters
-	std::string IfName =
-		(Direction == ELimitDirection::Upload) ? WDaemonConfig::GetInstance().NetworkInterfaceName : WIPLink::IfbDev;
+	std::string const IfName =
+		Direction == ELimitDirection::Upload ? WDaemonConfig::GetInstance().NetworkInterfaceName : WIPLink::IfbDev;
 
 	WIPLinkMsg Msg{};
 	Msg.Type = EIPLinkMsgType::RemoveHtbClass;
@@ -58,10 +58,12 @@ WBandwidthLimit::~WBandwidthLimit()
 	Msg.RemoveHtbClass->InterfaceName = IfName;
 	Msg.RemoveHtbClass->Mark = Mark;
 	Msg.RemoveHtbClass->MinorId = MinorId;
+	Msg.RemoveHtbClass->bIsRoot = bIsRoot;
 	WIPLink::GetInstance().IpProcSocket->SendMessage(Msg);
 }
 
-void WIPLink::SetupHTBLimitClass(std::shared_ptr<WBandwidthLimit> const& Limit, std::string const& IfName) const
+void WIPLink::SetupHTBLimitClass(
+	std::shared_ptr<WBandwidthLimit> const& Limit, std::string const& IfName, bool const bIsRoot) const
 {
 	spdlog::debug("Setting up HTB class on interface {}: classid=1:{}, mark=0x{:x}, rate={} B/s", IfName,
 		Limit->MinorId, Limit->Mark, Limit->RateLimit);
@@ -73,6 +75,7 @@ void WIPLink::SetupHTBLimitClass(std::shared_ptr<WBandwidthLimit> const& Limit, 
 	Msg.SetupHtbClass->Mark = Limit->Mark;
 	Msg.SetupHtbClass->MinorId = Limit->MinorId;
 	Msg.SetupHtbClass->RateLimit = Limit->RateLimit;
+	Msg.SetupHtbClass->bIsRoot = bIsRoot;
 	IpProcSocket->SendMessage(Msg);
 }
 
@@ -181,7 +184,7 @@ bool WIPLink::Init()
 		return false;
 	}
 
-	IpProcSocket->OnData.connect([](WBuffer& Data) { OnDataReceived(Data); });
+	IpProcSocket->OnData.connect([](WBuffer const& Data) { OnDataReceived(Data); });
 	IpProcSocket->StartListenThread();
 
 	spdlog::debug("IP link process socket connected");
@@ -198,33 +201,33 @@ bool WIPLink::Deinit()
 	return true;
 }
 
-void WIPLink::SetupEgressHTBClass(std::shared_ptr<WBandwidthLimit> const& Limit) const
+void WIPLink::SetupEgressHTBClass(std::shared_ptr<WBandwidthLimit> const& Limit, bool const bIsRoot) const
 {
-	SetupHTBLimitClass(Limit, WDaemonConfig::GetInstance().NetworkInterfaceName);
+	SetupHTBLimitClass(Limit, WDaemonConfig::GetInstance().NetworkInterfaceName, bIsRoot);
 }
 
-void WIPLink::SetupIngressHTBClass(std::shared_ptr<WBandwidthLimit> const& Limit) const
+void WIPLink::SetupIngressHTBClass(std::shared_ptr<WBandwidthLimit> const& Limit, bool const bIsRoot) const
 {
-	SetupHTBLimitClass(Limit, IfbDev);
+	SetupHTBLimitClass(Limit, IfbDev, bIsRoot);
 }
 
-void WIPLink::SetupIngressPortRouting(WTrafficItemId, uint32_t DownloadMark, uint16_t Dport)
+void WIPLink::SetupIngressPortRouting(WTrafficItemId, uint32_t const DownloadMark, uint16_t const DestPort)
 {
 	auto const& Data = WDaemon::GetInstance().GetEbpfObj().GetData();
 
-	if (!Data->SocketMarks->Update(Dport, static_cast<uint16_t>(DownloadMark)))
+	if (!Data->SocketMarks->Update(DestPort, static_cast<uint16_t>(DownloadMark)))
 	{
-		spdlog::error("Failed to add socket mark for port {}", Dport);
+		spdlog::error("Failed to add socket mark for port {}", DestPort);
 	}
 }
 
-void WIPLink::RemoveIngressPortRouting(uint16_t Dport)
+void WIPLink::RemoveIngressPortRouting(uint16_t const DestPort)
 {
 	auto const& Data = WDaemon::GetInstance().GetEbpfObj().GetData();
 
-	if (!Data->SocketMarks->Update(Dport, 0))
+	if (!Data->SocketMarks->Update(DestPort, 0))
 	{
-		spdlog::error("Failed to remove socket mark for port {}", Dport);
+		spdlog::error("Failed to remove socket mark for port {}", DestPort);
 	}
 }
 
@@ -305,7 +308,7 @@ std::shared_ptr<WBandwidthLimit> WIPLink::GetUploadLimit(
 		{
 			// Update existing limit
 			ExistingLimit->RateLimit = Limit;
-			SetupEgressHTBClass(ExistingLimit);
+			SetupEgressHTBClass(ExistingLimit, ItemId == 0);
 		}
 		if (bExists)
 		{
@@ -318,11 +321,11 @@ std::shared_ptr<WBandwidthLimit> WIPLink::GetUploadLimit(
 		*bExists = false;
 	}
 	auto NewLimit = std::make_shared<WBandwidthLimit>(
-		NextMark.fetch_add(1), NextMinorId.fetch_add(1), Limit, ELimitDirection::Upload);
+		NextMark.fetch_add(1), NextMinorId.fetch_add(1), Limit, ELimitDirection::Upload, ItemId == 0);
 
 	ActiveUploadLimits[ItemId] = NewLimit;
 
-	SetupEgressHTBClass(NewLimit);
+	SetupEgressHTBClass(NewLimit, ItemId == 0);
 
 	return NewLimit;
 }
@@ -333,12 +336,12 @@ std::shared_ptr<WBandwidthLimit> WIPLink::GetDownloadLimit(
 	std::lock_guard Lock(Mutex);
 	if (ActiveDownloadLimits.contains(ItemId))
 	{
-		auto ExistingLimit = ActiveDownloadLimits[ItemId];
+		auto const ExistingLimit = ActiveDownloadLimits[ItemId];
 		if (ExistingLimit->RateLimit != Limit)
 		{
 			// Update existing limit
 			ExistingLimit->RateLimit = Limit;
-			SetupIngressHTBClass(ExistingLimit);
+			SetupIngressHTBClass(ExistingLimit, ItemId == 0);
 		}
 		if (bExists)
 		{
@@ -352,10 +355,10 @@ std::shared_ptr<WBandwidthLimit> WIPLink::GetDownloadLimit(
 	}
 
 	auto NewLimit = std::make_shared<WBandwidthLimit>(
-		NextMark.fetch_add(1), NextMinorId.fetch_add(1), Limit, ELimitDirection::Download);
+		NextMark.fetch_add(1), NextMinorId.fetch_add(1), Limit, ELimitDirection::Download, ItemId == 0);
 	ActiveDownloadLimits[ItemId] = NewLimit;
 
-	SetupIngressHTBClass(NewLimit);
+	SetupIngressHTBClass(NewLimit, ItemId == 0);
 
 	return NewLimit;
 }

--- a/Source/Daemon/Net/IPLink.hpp
+++ b/Source/Daemon/Net/IPLink.hpp
@@ -31,9 +31,11 @@ struct WBandwidthLimit
 	ELimitDirection Direction;
 	uint32_t        Mark{ 0 };      // Traffic mark used in tc filters to redirect the packet to the correct class
 	uint16_t        MinorId{ 0 };   // Minor class ID in the HTB qdisc
+	bool            bIsRoot{};
 	WBytesPerSecond RateLimit{ 0 }; // Bandwidth limit in bytes per second
 
-	WBandwidthLimit(uint32_t Mark, uint16_t MinorId, WBytesPerSecond RateLimit, ELimitDirection Direction);
+	WBandwidthLimit(
+		uint32_t Mark_, uint16_t MinorId_, WBytesPerSecond RateLimit_, ELimitDirection Direction_, bool bIsRoot_);
 	~WBandwidthLimit();
 };
 
@@ -43,7 +45,7 @@ class WIPLink : public TSingleton<WIPLink>, public IMemoryTrackable
 {
 	friend struct WBandwidthLimit;
 	std::mutex            Mutex;
-	std::atomic<uint32_t> NextFilterhandle{ 1 };
+	std::atomic<uint32_t> NextFilterHandle{ 1 };
 	std::atomic<uint32_t> NextMark{ 1 };
 	std::atomic<uint16_t> NextMinorId{ 11 }; // 10 is root
 
@@ -52,9 +54,10 @@ class WIPLink : public TSingleton<WIPLink>, public IMemoryTrackable
 
 	std::unique_ptr<WClientSocket> IpProcSocket;
 
-	void SetupHTBLimitClass(std::shared_ptr<WBandwidthLimit> const& Limit, std::string const& IfName) const;
+	void SetupHTBLimitClass(
+		std::shared_ptr<WBandwidthLimit> const& Limit, std::string const& IfName, bool bIsRoot) const;
 	void OnSocketRemoved(std::shared_ptr<WSocketCounter> const& Socket);
-	static void OnDataReceived(WBuffer const& data);
+	static void OnDataReceived(WBuffer const& Buf);
 
 public:
 	unsigned int             WaechterIngressIfIndex{ 0 };
@@ -63,11 +66,11 @@ public:
 	bool Init();
 	bool Deinit();
 
-	void SetupEgressHTBClass(std::shared_ptr<WBandwidthLimit> const& Limit) const;
-	void SetupIngressHTBClass(std::shared_ptr<WBandwidthLimit> const& Limit) const;
+	void SetupEgressHTBClass(std::shared_ptr<WBandwidthLimit> const& Limit, bool bIsRoot) const;
+	void SetupIngressHTBClass(std::shared_ptr<WBandwidthLimit> const& Limit, bool bIsRoot) const;
 
-	static void SetupIngressPortRouting(WTrafficItemId Item, uint32_t QDiscId, uint16_t Dport);
-	static void RemoveIngressPortRouting(uint16_t Dport);
+	static void SetupIngressPortRouting(WTrafficItemId Item, uint32_t DownloadMark, uint16_t DestPort);
+	static void RemoveIngressPortRouting(uint16_t DestPort);
 
 	void RemoveUploadLimit(WTrafficItemId const& ItemId);
 	void RemoveDownloadLimit(WTrafficItemId const& ItemId);

--- a/Source/Daemon/Net/IPLinkProc/IPLinkProc.cpp
+++ b/Source/Daemon/Net/IPLinkProc/IPLinkProc.cpp
@@ -124,6 +124,15 @@ static std::string SanitizeInterfaceName(std::string const& IfName)
 static bool SetupHtbClass(std::shared_ptr<WSetupHtbClassMsg> const& SetupHtbClass)
 {
 	auto const IfName = SanitizeInterfaceName(SetupHtbClass->InterfaceName);
+	if (SetupHtbClass->bIsRoot)
+	{
+		spdlog::info("Setting up root HTB class on interface {}: classid=1:{}, mark=0x{:x}, rate={} B/s", IfName,
+			SetupHtbClass->MinorId, SetupHtbClass->Mark, SetupHtbClass->RateLimit);
+		SYSFMT("tc class replace dev {} parent 1:1 classid 1:10 htb rate {} ceil {}", IfName, SetupHtbClass->RateLimit,
+			SetupHtbClass->RateLimit);
+		return true;
+	}
+
 	spdlog::debug("Setting up HTB class on interface {}: classid=1:{}, mark=0x{:x}, rate={} B/s", IfName,
 		SetupHtbClass->MinorId, SetupHtbClass->Mark, SetupHtbClass->RateLimit);
 	SYSFMT("tc class replace dev {} parent 1:1 classid 1:{} htb rate {}bit ceil {}bit", IfName, SetupHtbClass->MinorId,
@@ -141,6 +150,14 @@ static bool SetupHtbClass(std::shared_ptr<WSetupHtbClassMsg> const& SetupHtbClas
 static bool RemoveHtbClass(std::shared_ptr<WRemoveHtbClassMsg> const& RemoveHtbClass)
 {
 	auto const& IfName = SanitizeInterfaceName(RemoveHtbClass->InterfaceName);
+
+	if (RemoveHtbClass->bIsRoot)
+	{
+		spdlog::info("Resetting root HTB class on interface {}: classid=1:{}, mark=0x{:x}", IfName,
+			RemoveHtbClass->MinorId, RemoveHtbClass->Mark);
+		SYSFMT("tc class replace dev {} parent 1:1 classid 1:10 htb rate 1Gbit ceil 1Gbit", IfName);
+		return true;
+	}
 	spdlog::debug("Removing HTB class on interface {}: classid=1:{}, mark=0x{:x}", IfName, RemoveHtbClass->MinorId,
 		RemoveHtbClass->Mark);
 

--- a/Source/Daemon/Net/IPLinkProc/IPLinkProc.cpp
+++ b/Source/Daemon/Net/IPLinkProc/IPLinkProc.cpp
@@ -15,11 +15,12 @@
 #include "spdlog/spdlog.h"
 #include "spdlog/fmt/fmt.h"
 #include "cereal/types/memory.hpp"
-// ReSharper disable once CppUnusedIncludeDirective
+// ReSharper disable CppUnusedIncludeDirective
 #include "cereal/types/string.hpp"
 #include "cereal/types/array.hpp"
 #include "cereal/types/vector.hpp"
 #include "cereal/types/tuple.hpp"
+// ReSharper enable CppUnusedIncludeDirective
 
 #include "Socket.hpp"
 #include "ErrnoUtil.hpp"
@@ -27,8 +28,10 @@
 #include "SignalHandler.hpp"
 #include "Data/SocketStateParser.hpp"
 
-// The sole purpose of this executable is to run `tc` commands which require root
-// Commands are sent via unix socket from waechterd after it has dropped privileges
+// The sole purpose of this executable is to run `tc` commands which require root.
+// Commands are sent via unix socket from waechterd after it has dropped privileges.
+// At some point we should probably replace the `tc` command with directly using the
+// ip link library.
 
 #define SYSFMT(_fmt, ...)                                                                                             \
 	if (auto RC = SafeSystem(fmt::format(_fmt, __VA_ARGS__).c_str()); RC != 0)                                        \
@@ -50,20 +53,6 @@ struct WMsgQueue;
 static bool RemoveHtbClass(std::shared_ptr<WRemoveHtbClassMsg> const& RemoveHtbClass);
 
 static void ProcessMessage(WMsgQueue& Queue, WIPLinkMsg const& Msg, WSignalHandler& Handler, std::string const& IfbDev);
-
-struct HTBMapEntry
-{
-	uint16_t                            UseCount{};
-	std::shared_ptr<WRemoveHtbClassMsg> PendingRemoveMsg{};
-
-	~HTBMapEntry()
-	{
-		if (PendingRemoveMsg != nullptr)
-		{
-			RemoveHtbClass(PendingRemoveMsg);
-		}
-	}
-};
 
 // A tiny bounded-ish queue to avoid unbounded RAM usage if the sender outruns `tc`.
 // If it grows too large, we log warnings so it's visible in the logs.
@@ -128,9 +117,7 @@ static int SafeSystem(std::string const& Command)
 static std::string SanitizeInterfaceName(std::string const& IfName)
 {
 	std::string Result = IfName;
-	Result.erase(
-		std::remove_if(Result.begin(), Result.end(), [](char c) { return !std::isalnum(c) && c != '_' && c != '-'; }),
-		Result.end());
+	std::erase_if(Result, [](char c) { return !std::isalnum(c) && c != '_' && c != '-'; });
 	return Result;
 }
 

--- a/Source/Daemon/Net/IPLinkProc/IPLinkProc.cpp
+++ b/Source/Daemon/Net/IPLinkProc/IPLinkProc.cpp
@@ -128,8 +128,13 @@ static bool SetupHtbClass(std::shared_ptr<WSetupHtbClassMsg> const& SetupHtbClas
 	{
 		spdlog::info("Setting up root HTB class on interface {}: classid=1:{}, mark=0x{:x}, rate={} B/s", IfName,
 			SetupHtbClass->MinorId, SetupHtbClass->Mark, SetupHtbClass->RateLimit);
-		SYSFMT("tc class replace dev {} parent 1:1 classid 1:10 htb rate {} ceil {}", IfName, SetupHtbClass->RateLimit,
-			SetupHtbClass->RateLimit);
+		SYSFMT("tc class replace dev {} parent 1:1 classid 1:10 htb rate {}bit ceil {}bit", IfName,
+			static_cast<uint64_t>(SetupHtbClass->RateLimit * 8), static_cast<uint64_t>(SetupHtbClass->RateLimit * 8));
+		// Use fq_codel as the leaf qdisc instead of the implicit pfifo (whose limit is derived from the
+		// device's tx_queue_len). This matters a lot on the ifb device, whose tx_queue_len defaults to a
+		// tiny 32 packets: without a proper AQM/buffer, low rate limits cause bursty tail-drops that make
+		// TCP collapse its window, so achieved throughput ends up far below the configured rate.
+		SYSFMT("tc qdisc replace dev {} parent 1:10 fq_codel", IfName);
 		return true;
 	}
 
@@ -137,6 +142,8 @@ static bool SetupHtbClass(std::shared_ptr<WSetupHtbClassMsg> const& SetupHtbClas
 		SetupHtbClass->MinorId, SetupHtbClass->Mark, SetupHtbClass->RateLimit);
 	SYSFMT("tc class replace dev {} parent 1:1 classid 1:{} htb rate {}bit ceil {}bit", IfName, SetupHtbClass->MinorId,
 		static_cast<uint64_t>(SetupHtbClass->RateLimit * 8), static_cast<uint64_t>(SetupHtbClass->RateLimit * 8));
+	// See comment above: give every leaf class its own AQM qdisc rather than relying on the implicit pfifo.
+	SYSFMT("tc qdisc replace dev {} parent 1:{} fq_codel", IfName, SetupHtbClass->MinorId);
 
 	spdlog::info("Setup filter with mark {}", SetupHtbClass->Mark);
 	SYSFMT("tc filter replace dev {} parent 1: protocol ip pref 1 handle 0x{:x} fw classid 1:{}", IfName,
@@ -175,6 +182,12 @@ static bool Init(std::string const& IfbDev, std::string const& IngressInterface,
 	// Create the ifb0 interface
 	SafeSystem(fmt::format("ip link delete {}", IfbDev));
 	SafeSystem(fmt::format("ip link add {0} type ifb", IfbDev));
+	// The ifb driver defaults tx_queue_len to a tiny 32 packets. That length backs the implicit pfifo
+	// queue of any HTB leaf class that doesn't have its own qdisc, so ingress shaping ends up with almost
+	// no buffer: bursty download traffic instantly tail-drops once it exceeds the configured rate, which
+	// makes TCP collapse its window and achieve throughput far below the configured limit. Raise it here;
+	// fq_codel (attached to the leaf classes below/in SetupHtbClass) also acts as the actual AQM.
+	SYSFMT("ip link set {0} txqueuelen 1000", IfbDev);
 	SYSFMT("ip link set {0} up", IfbDev);
 
 	// Ingress HTB setup (on IFB device)
@@ -185,6 +198,7 @@ static bool Init(std::string const& IfbDev, std::string const& IngressInterface,
 	SYSFMT("tc class replace dev {} parent 1:1 classid 1:10 "
 		   "htb rate 1Gbit ceil 1Gbit",
 		IfbDev);
+	SYSFMT("tc qdisc replace dev {} parent 1:10 fq_codel", IfbDev);
 	// Default filter
 	SYSFMT("tc filter replace dev {} parent 1: prio 100 protocol all u32 match u32 0 0 flowid 1:10", IfbDev);
 
@@ -202,6 +216,7 @@ static bool Init(std::string const& IfbDev, std::string const& IngressInterface,
 	SYSFMT("tc class replace dev {} parent 1: classid 1:1 htb rate 1Gbit ceil 1Gbit", MainInterface);
 	// leaf class for egress
 	SYSFMT("tc class replace dev {} parent 1:1 classid 1:10 htb rate 1Gbit ceil 1Gbit", MainInterface);
+	SYSFMT("tc qdisc replace dev {} parent 1:10 fq_codel", MainInterface);
 
 	return true;
 }

--- a/Source/Daemon/Rules/RuleManager.cpp
+++ b/Source/Daemon/Rules/RuleManager.cpp
@@ -500,6 +500,17 @@ void WRuleManager::HandleRuleChange(WBuffer const& Buf, WDaemonClient const* Sen
 		return;
 	}
 
+	if (Item->GetType() == TI_System)
+	{
+		// We also store the system rule with cookie 0 in ebpf.
+		// That way we can immediately determine if all traffic should be blocked
+		auto const EbpfData = WDaemon::GetInstance().GetEbpfObj().GetData();
+		if (!EbpfData->SocketRules->Update(0, Update.Rules.AsBase()))
+		{
+			spdlog::error("Failed to update eBPF rules for system rule");
+		}
+	}
+
 	if (Update.Rules.DownloadLimit == 0)
 	{
 		if (auto const SocketItem = std::dynamic_pointer_cast<WSocketItem>(Item))

--- a/Source/Daemon/Rules/RuleManager.cpp
+++ b/Source/Daemon/Rules/RuleManager.cpp
@@ -94,8 +94,9 @@ void WRuleManager::OnSocketConnected(WSocketCounter const* Socket)
 	auto const App = Socket->ParentProcess->ParentApp;
 
 	auto const AppRules = ApplicationRules.contains(AppItem) ? ApplicationRules[AppItem] : WTrafficItemRules{};
+	auto const EffectiveAppRules = GetEffectiveRules(SystemRules, AppRules);
 	auto const ProcRules = ProcessRules.contains(ProcessItemId) ? ProcessRules[ProcessItemId] : WTrafficItemRules{};
-	WTrafficItemRules const EffectiveProcRules = GetEffectiveRules(AppRules, ProcRules);
+	WTrafficItemRules const EffectiveProcRules = GetEffectiveRules(EffectiveAppRules, ProcRules);
 
 	if (!EffectiveProcRules.IsDefault())
 	{
@@ -187,21 +188,77 @@ void WRuleManager::OnAppFirstTimeConnected(std::shared_ptr<WAppCounter> const& A
 	});
 }
 
+void WRuleManager::LoadSystemRule()
+{
+	WDbManager::GetInstance().Run([this](auto& DbConn) {
+		constexpr Db::Schema::Rule Rule;
+		auto RuleResult =
+			DbConn(sqlpp::select(Rule.DownloadLimit, Rule.UploadLimit, Rule.DownloadSwitchState, Rule.UploadSwitchState)
+					.from(Rule)
+					.where(Rule.Target == "system"));
+
+		if (RuleResult.empty())
+		{
+			return;
+		}
+
+		spdlog::debug("Loading rule for system");
+		WTrafficItemRules Rules;
+		Rules.DownloadSwitch = static_cast<ESwitchState>(static_cast<int>(RuleResult.front().DownloadSwitchState));
+		Rules.UploadSwitch = static_cast<ESwitchState>(static_cast<int>(RuleResult.front().UploadSwitchState));
+		Rules.RuleType = ERuleType::Explicit;
+		Rules.DownloadLimit = RuleResult.front().DownloadLimit;
+		Rules.UploadLimit = RuleResult.front().UploadLimit;
+
+		if (Rules.DownloadLimit > 0)
+		{
+			auto const Limit = WIPLink::GetInstance().GetDownloadLimit(0, Rules.DownloadLimit);
+			Rules.DownloadMark = Limit->Mark;
+		}
+		if (Rules.UploadLimit > 0)
+		{
+			auto const Limit = WIPLink::GetInstance().GetUploadLimit(0, Rules.UploadLimit);
+			Rules.UploadMark = Limit->Mark;
+		}
+
+		if (!Rules.IsDefault())
+		{
+			std::lock_guard Lock(Mutex);
+			SystemRules = Rules;
+			UpdateRuleCache(WSystemMap::GetInstance().GetSystemItem());
+			SyncRules();
+		}
+	});
+}
+
 void WRuleManager::UpdateRuleCache(std::shared_ptr<ITrafficItem> const& AppItem)
 {
+	if (!AppItem)
+	{
+		return;
+	}
+	if (AppItem->GetType() == TI_System)
+	{
+		for (auto const& App : WSystemMap::GetInstance().GetSystemItem()->Applications | std::views::values)
+		{
+			UpdateRuleCache(App);
+		}
+		return;
+	}
+
 	auto const App = std::dynamic_pointer_cast<WApplicationItem>(AppItem);
 	if (!App)
 	{
 		return;
 	}
 
-	WTrafficItemRules const AppRules =
-		ApplicationRules.contains(App->ItemId) ? ApplicationRules[App->ItemId] : WTrafficItemRules{};
+	auto const AppRules = ApplicationRules.contains(App->ItemId) ? ApplicationRules[App->ItemId] : WTrafficItemRules{};
+	WTrafficItemRules const EffectiveAppRules = GetEffectiveRules(SystemRules, AppRules);
 
 	for (auto const& Proc : App->Processes | std::views::values)
 	{
 		auto const ProcRules = ProcessRules.contains(Proc->ItemId) ? ProcessRules[Proc->ItemId] : WTrafficItemRules{};
-		WTrafficItemRules const EffectiveProcRules = GetEffectiveRules(AppRules, ProcRules);
+		WTrafficItemRules const EffectiveProcRules = GetEffectiveRules(EffectiveAppRules, ProcRules);
 
 		for (auto const& [Cookie, Sock] : Proc->Sockets)
 		{
@@ -275,6 +332,10 @@ void WRuleManager::SyncRules()
 
 void WRuleManager::RemoveEmptyRules()
 {
+	if (SystemRules.IsDefault())
+	{
+		SystemRules = {};
+	}
 	auto CleanUp = [](std::unordered_map<WTrafficItemId, WTrafficItemRules>& Map) {
 		for (auto It = Map.begin(); It != Map.end();)
 		{
@@ -340,9 +401,53 @@ void WRuleManager::WriteAppRuleToDb(WRuleUpdate const& Update, std::shared_ptr<W
 	});
 }
 
+void WRuleManager::WriteSystemRuleToDb(WRuleUpdate const& Update)
+{
+	WDbManager::GetInstance().Run([&](auto& DbConn) {
+		constexpr Db::Schema::Rule Rule;
+		auto RuleResult = DbConn(sqlpp::select(Rule.ID).from(Rule).where(Rule.Target == "system"));
+
+		if (RuleResult.empty())
+		{
+			if (!Update.Rules.IsDefault())
+			{
+				DbConn(sqlpp::insert_into(Rule).set(Rule.Target = "system", Rule.DownloadLimit = Update.Rules.DownloadLimit,
+					Rule.UploadLimit = Update.Rules.UploadLimit,
+					Rule.DownloadSwitchState = static_cast<int>(Update.Rules.DownloadSwitch),
+					Rule.UploadSwitchState = static_cast<int>(Update.Rules.UploadSwitch)));
+			}
+			return;
+		}
+
+		int64_t const RuleID = RuleResult.front().ID.value();
+
+		if (Update.Rules.IsDefault())
+		{
+			DbConn(sqlpp::remove_from(Rule).where(Rule.ID == RuleID));
+		}
+		else
+		{
+			DbConn(sqlpp::update(Rule)
+					.set(Rule.DownloadLimit = Update.Rules.DownloadLimit, Rule.UploadLimit = Update.Rules.UploadLimit,
+						Rule.DownloadSwitchState = static_cast<int>(Update.Rules.DownloadSwitch),
+						Rule.UploadSwitchState = static_cast<int>(Update.Rules.UploadSwitch))
+					.where(Rule.ID == RuleID));
+		}
+	});
+}
+
 void WRuleManager::SendCurrentRulesToClient(std::shared_ptr<WDaemonClient> const& Client)
 {
 	std::scoped_lock Lock(Mutex);
+
+	if (!SystemRules.IsDefault())
+	{
+		WRuleUpdate Update{};
+		Update.TrafficItemId = 0;
+		Update.ParentAppId = 0;
+		Update.Rules = SystemRules;
+		Client->SendMessage(MT_RuleUpdate, Update);
+	}
 
 	auto SendMap = [Client](std::unordered_map<WTrafficItemId, WTrafficItemRules> const& Map) {
 		for (auto const& [TrafficItemId, Rules] : Map)
@@ -369,6 +474,7 @@ void WRuleManager::RegisterSignalHandlers()
 		[this](std::shared_ptr<WProcessCounter> const& Process) { OnProcessRemoved(Process); });
 	WNetworkEvents::GetInstance().OnAppFirstTimeConnected.connect(
 		[this](std::shared_ptr<WAppCounter> const& App) { OnAppFirstTimeConnected(App); });
+	LoadSystemRule();
 }
 
 void WRuleManager::HandleRuleChange(WBuffer const& Buf, WDaemonClient const* Sender)
@@ -386,8 +492,9 @@ void WRuleManager::HandleRuleChange(WBuffer const& Buf, WDaemonClient const* Sen
 
 	auto const Item = WSystemMap::GetInstance().GetTrafficItemById(Update.TrafficItemId);
 	auto const AppItem = WSystemMap::GetInstance().GetTrafficItemById(Update.ParentAppId);
+	auto const CacheRoot = Item && Item->GetType() == TI_System ? Item : AppItem;
 
-	if (!Item || !AppItem)
+	if (!Item || !CacheRoot)
 	{
 		spdlog::warn("Received rule update for unknown traffic item ID {}", Update.TrafficItemId);
 		return;
@@ -423,6 +530,10 @@ void WRuleManager::HandleRuleChange(WBuffer const& Buf, WDaemonClient const* Sen
 
 	switch (Item->GetType())
 	{
+		case TI_System:
+			SystemRules = Update.Rules;
+			WriteSystemRuleToDb(Update);
+			break;
 		case TI_Application:
 		{
 			ApplicationRules[Update.TrafficItemId] = Update.Rules;
@@ -467,7 +578,7 @@ void WRuleManager::HandleRuleChange(WBuffer const& Buf, WDaemonClient const* Sen
 		default:;
 	}
 
-	UpdateRuleCache(AppItem);
+	UpdateRuleCache(CacheRoot);
 	SyncRules();
 	RemoveEmptyRules();
 	spdlog::debug("{} app rules, {} proc rules, {} sock rules, {} sock cookie rules in cache", ApplicationRules.size(),

--- a/Source/Daemon/Rules/RuleManager.hpp
+++ b/Source/Daemon/Rules/RuleManager.hpp
@@ -23,7 +23,7 @@ class WDaemonClient;
 
 struct WSocketRules
 {
-	WTrafficItemRulesBase Rules;
+	WTrafficItemRulesBase Rules{};
 	WTrafficItemId        SocketId{};
 
 	bool bDirty{ true };
@@ -33,6 +33,7 @@ class WRuleManager : public TSingleton<WRuleManager>, public IMemoryTrackable
 {
 	std::mutex Mutex;
 
+	WTrafficItemRules                                     SystemRules{};
 	std::unordered_map<WTrafficItemId, WTrafficItemRules> ApplicationRules;
 	std::unordered_map<WTrafficItemId, WTrafficItemRules> ProcessRules;
 	std::unordered_map<WTrafficItemId, WTrafficItemRules> SocketRules;
@@ -43,11 +44,13 @@ class WRuleManager : public TSingleton<WRuleManager>, public IMemoryTrackable
 	void OnSocketRemoved(std::shared_ptr<WSocketCounter> const& Socket);
 	void OnProcessRemoved(std::shared_ptr<WProcessCounter> const& ProcessItem);
 	void OnAppFirstTimeConnected(std::shared_ptr<WAppCounter> const& App);
+	void LoadSystemRule();
 
 	void UpdateRuleCache(std::shared_ptr<ITrafficItem> const& AppItem);
 	void SyncRules();
 	void RemoveEmptyRules();
 	static void WriteAppRuleToDb(WRuleUpdate const& Update, std::shared_ptr<WApplicationItem> const& App);
+	static void WriteSystemRuleToDb(WRuleUpdate const& Update);
 
 public:
 	void SendCurrentRulesToClient(std::shared_ptr<WDaemonClient> const& Client);

--- a/Source/EBPF/EBPFTraffic.h
+++ b/Source/EBPF/EBPFTraffic.h
@@ -26,6 +26,12 @@ int cgskb_ingress(struct __sk_buff* Skb)
 	__u64 Cookie = bpf_get_socket_cookie(Skb);
 
 	struct WTrafficItemRulesBase* Rules = GetSocketRules(Cookie);
+	struct WTrafficItemRulesBase* SystemRules = GetSocketRules(0);
+
+	if (SystemRules && SystemRules->DownloadSwitch == SS_Block)
+	{
+		return SK_DROP;
+	}
 	if (Rules && Rules->DownloadSwitch == SS_Block)
 	{
 		return SK_DROP;
@@ -73,6 +79,12 @@ int cgskb_egress(struct __sk_buff* Skb)
 	__u64 Cookie = bpf_get_socket_cookie(Skb);
 
 	struct WTrafficItemRulesBase* Rules = GetSocketRules(Cookie);
+	struct WTrafficItemRulesBase* SystemRules = GetSocketRules(0);
+
+	if (SystemRules && SystemRules->UploadSwitch == SS_Block)
+	{
+		return SK_DROP;
+	}
 	if (Rules && Rules->UploadSwitch == SS_Block)
 	{
 		return SK_DROP;

--- a/Source/Gui/Client.cpp
+++ b/Source/Gui/Client.cpp
@@ -69,7 +69,7 @@ void WClient::OnDataReceived(WBuffer& Buf)
 			WMainWindow::Get().HandleHistoryResponse(Buf);
 			break;
 		case MT_IPLookupResponse:
-			WMainWindow::Get().GetDailyDetailsWindow().HandleLookupResult(Buf);
+			WMainWindow::Get().GetDetailsWindow().HandleLookupResult(Buf);
 			break;
 		case MT_RuleUpdate:
 			WClientRuleManager::GetInstance().HandleRuleUpdate(Buf);

--- a/Source/Gui/Util/RuleWidget.cpp
+++ b/Source/Gui/Util/RuleWidget.cpp
@@ -11,11 +11,14 @@
 #include "Icons/IconAtlas.hpp"
 #include "ClientRuleManager.hpp"
 #include "EBPFCommon.h"
+#include "I18n.hpp"
 #include "ImGuiUtil.hpp"
+#include "Settings.hpp"
 #include "Windows/SdlWindow.hpp"
 
 static constexpr ImVec2 GRuleIconSize{ 16, 16 };
 static constexpr float  GIconSpacing = 4.0f;
+static constexpr ImVec2 GWarningPopupSize{ 260, 0 };
 static WBytesPerSecond  CurrentLimit = 0;
 static ETrafficUnit     SelectedUnit = TU_KiBps;
 
@@ -153,10 +156,100 @@ static bool DrawBlockIconButton(
 		"placeholder", WSdlWindow::ScaleSize(GRuleIconSize), true);
 }
 
+void WRuleWidget::DrawWarningPopup(WRenderItemArgs const& Args)
+{
+	auto const Item = Args.Item;
+	auto const PopupLabel = std::format("warning_popup_{}", Item->ItemId);
+
+	ImGui::SetNextWindowSize(WSdlWindow::ScaleSize(GWarningPopupSize), ImGuiCond_Appearing);
+	if (!ImGui::BeginPopup(PopupLabel.c_str(), ImGuiWindowFlags_NoMove))
+	{
+		return;
+	}
+
+	ImGui::PushTextWrapPos(0.0f);
+	ImGui::TextWrapped("%s", TR("lockout_warning_text"));
+	ImGui::PopTextWrapPos();
+	if (ImGui::Button(TR("generic.ok")))
+	{
+		ImGui::CloseCurrentPopup();
+		bOpenPendingPopup = true;
+	}
+	ImGui::EndPopup();
+}
+
 void WRuleWidget::Draw(WRenderItemArgs const& Args, bool)
 {
-	auto               Item = Args.Item;
-	WTrafficItemRules* Rules{};
+	auto const               Item = Args.Item;
+	WTrafficItemRules const* Rules{};
+
+	if (bOpenPendingPopup)
+	{
+		if (PendingPopupItemId == Item->ItemId)
+		{
+			ImGui::OpenPopup(PendingPopupName.c_str());
+			bOpenPendingPopup = false;
+			PendingPopupName.clear();
+			PendingPopupItemId.reset();
+		}
+	}
+
+	auto const OpenPopup = [&](std::string const& Name) {
+		bool const bIsSystemItem = Args.Item->ItemId == 0;
+		bool       bIsDaemonOrClientItem{};
+		if (Args.Item->GetType() == TI_Application)
+		{
+			auto const& App = std::static_pointer_cast<WApplicationItem>(Args.Item);
+			if (App->ApplicationName == "waechterd" || App->ApplicationName == "waechter")
+			{
+				bIsDaemonOrClientItem = true;
+			}
+		}
+		else if (Args.Item->GetType() == TI_Process)
+		{
+			auto const& Process = std::static_pointer_cast<WProcessItem>(Args.Item);
+			if (auto const Client = WMainWindow::GetTrafficTree()->FindClientItem())
+			{
+				bIsDaemonOrClientItem |= Client->Processes.contains(Process->ProcessId);
+			}
+			if (auto const Daemon = WMainWindow::GetTrafficTree()->FindDaemonItem())
+			{
+				bIsDaemonOrClientItem |= Daemon->Processes.contains(Process->ProcessId);
+			}
+		}
+		else if (Args.Item->GetType() == TI_Socket)
+		{
+			auto const& Socket = std::static_pointer_cast<WSocketItem>(Args.Item);
+			auto const  Cookie = Socket->Cookie;
+			if (auto const Client = WMainWindow::GetTrafficTree()->FindClientItem())
+			{
+				for (auto const& Proc : Client->Processes | std::views::values)
+				{
+					bIsDaemonOrClientItem |= Proc->Sockets.contains(Cookie);
+				}
+			}
+			if (auto const Daemon = WMainWindow::GetTrafficTree()->FindDaemonItem())
+			{
+				for (auto const& Proc : Daemon->Processes | std::views::values)
+				{
+					bIsDaemonOrClientItem |= Proc->Sockets.contains(Cookie);
+				}
+			}
+		}
+
+		if ((bIsSystemItem || bIsDaemonOrClientItem) && WSettings::GetInstance().SocketPath.starts_with("ws"))
+		{
+			// we're messing with the system item, and we are connected via a websocket
+			// that means the user is pretty close to locking himself out
+			ImGui::OpenPopup(std::format("warning_popup_{}", Item->ItemId).c_str());
+			PendingPopupName = Name;
+			PendingPopupItemId = Item->ItemId;
+		}
+		else
+		{
+			ImGui::OpenPopup(Name.c_str());
+		}
+	};
 
 	// We do *not* want to create the rule here if it doesn't exist
 	if (WClientRuleManager::GetInstance().HasRules(Item->ItemId))
@@ -170,7 +263,7 @@ void WRuleWidget::Draw(WRenderItemArgs const& Args, bool)
 
 	if (DrawBlockIconButton(Item->ItemId, Rules->DownloadSwitch, "downloadallow", "downloadblock"))
 	{
-		ImGui::OpenPopup(std::format("download_popup_{}", Item->ItemId).c_str());
+		OpenPopup(std::format("download_popup_{}", Item->ItemId));
 	}
 	if (ImGui::IsItemHovered())
 	{
@@ -181,7 +274,7 @@ void WRuleWidget::Draw(WRenderItemArgs const& Args, bool)
 
 	if (DrawBlockIconButton(Item->ItemId, Rules->UploadSwitch, "uploadallow", "uploadblock"))
 	{
-		ImGui::OpenPopup(std::format("upload_popup_{}", Item->ItemId).c_str());
+		OpenPopup(std::format("upload_popup_{}", Item->ItemId));
 	}
 	if (ImGui::IsItemHovered())
 	{
@@ -190,11 +283,11 @@ void WRuleWidget::Draw(WRenderItemArgs const& Args, bool)
 	DrawBlockOptionPopup(Args, true);
 	ImGui::SameLine(0.0f, GIconSpacing);
 
-	auto Rule = WClientRuleManager::GetInstance().GetOrCreateRules(Item->ItemId);
+	auto const Rule = WClientRuleManager::GetInstance().GetOrCreateRules(Item->ItemId);
 	if (DrawLimitIconButton(Item->ItemId, Rule.DownloadLimit, "downloadlimit"))
 	{
 		CurrentLimit = WTrafficFormat::ConvertFromBps(Rule.DownloadLimit, SelectedUnit);
-		ImGui::OpenPopup(std::format("download_limit_popup_{}", Item->ItemId).c_str());
+		OpenPopup(std::format("download_limit_popup_{}", Item->ItemId));
 	}
 	if (ImGui::IsItemHovered())
 	{
@@ -206,11 +299,13 @@ void WRuleWidget::Draw(WRenderItemArgs const& Args, bool)
 	if (DrawLimitIconButton(Item->ItemId, Rule.UploadLimit, "uploadlimit"))
 	{
 		CurrentLimit = WTrafficFormat::ConvertFromBps(Rule.UploadLimit, SelectedUnit);
-		ImGui::OpenPopup(std::format("upload_limit_popup_{}", Item->ItemId).c_str());
+		OpenPopup(std::format("upload_limit_popup_{}", Item->ItemId));
 	}
 	if (ImGui::IsItemHovered())
 	{
 		ImGui::SetTooltip("Limit upload");
 	}
+
 	DrawLimitOptionPopup(Args, true);
+	DrawWarningPopup(Args);
 }

--- a/Source/Gui/Util/RuleWidget.hpp
+++ b/Source/Gui/Util/RuleWidget.hpp
@@ -4,7 +4,10 @@
  */
 
 #pragma once
+#include <optional>
+
 #include "Data/Rule.hpp"
+#include "Data/TrafficItem.hpp"
 
 struct ITrafficItem;
 
@@ -13,6 +16,11 @@ struct WRenderItemArgs;
 class WRuleWidget
 {
 	WTrafficItemRules EmptyDummyRules{};
+	std::string       PendingPopupName{};
+	std::optional<WTrafficItemId> PendingPopupItemId{};
+	bool              bOpenPendingPopup{};
+
+	void DrawWarningPopup(WRenderItemArgs const& Args);
 
 public:
 	void Draw(WRenderItemArgs const& Args, bool bSelected = false);

--- a/Source/Gui/Windows/DetailsWindow.cpp
+++ b/Source/Gui/Windows/DetailsWindow.cpp
@@ -79,7 +79,7 @@ static char const* ProtocolToString(EProtocol::Type Protocol)
 
 void WDetailsWindow::DrawFilterDetails() const
 {
-	auto const Filter = Tree->GetSeletedTrafficItem<WFilterItem>();
+	auto const Filter = Tree->GetSelectedTrafficItem<WFilterItem>();
 
 	if (Filter == nullptr)
 	{
@@ -105,7 +105,7 @@ void WDetailsWindow::DrawFilterDetails() const
 
 void WDetailsWindow::DrawSystemDetails() const
 {
-	auto const System = Tree->GetSeletedTrafficItem<WSystemItem>();
+	auto const System = Tree->GetSelectedTrafficItem<WSystemItem>();
 
 	if (System == nullptr)
 	{
@@ -136,7 +136,7 @@ void WDetailsWindow::DrawSystemDetails() const
 
 void WDetailsWindow::DrawApplicationDetails() const
 {
-	auto const App = Tree->GetSeletedTrafficItem<WApplicationItem>();
+	auto const App = Tree->GetSelectedTrafficItem<WApplicationItem>();
 	if (App == nullptr)
 	{
 		return;
@@ -175,7 +175,7 @@ void WDetailsWindow::DrawApplicationDetails() const
 
 void WDetailsWindow::DrawProcessDetails() const
 {
-	auto const Proc = Tree->GetSeletedTrafficItem<WProcessItem>();
+	auto const Proc = Tree->GetSelectedTrafficItem<WProcessItem>();
 	if (Proc == nullptr)
 	{
 		return;
@@ -192,7 +192,7 @@ void WDetailsWindow::DrawProcessDetails() const
 
 void WDetailsWindow::DrawSocketDetails() const
 {
-	auto const Sock = Tree->GetSeletedTrafficItem<WSocketItem>();
+	auto const Sock = Tree->GetSelectedTrafficItem<WSocketItem>();
 	if (Sock == nullptr)
 	{
 		return;
@@ -268,7 +268,7 @@ void WDetailsWindow::DrawSocketDetails() const
 
 void WDetailsWindow::DrawTupleDetails() const
 {
-	auto const Tuple = Tree->GetSeletedTrafficItem<WTupleItem>();
+	auto const Tuple = Tree->GetSelectedTrafficItem<WTupleItem>();
 	auto const Endpoint = Tree->GetSelectedTupleEndpoint();
 	if (!Tuple || !Endpoint.has_value())
 	{
@@ -327,7 +327,7 @@ void WDetailsWindow::Draw()
 		}
 	}
 
-	auto const Sock = Tree->GetSeletedTrafficItem<WSocketItem>();
+	auto const Sock = Tree->GetSelectedTrafficItem<WSocketItem>();
 	if (Sock)
 	{
 		if (LookupCache.contains(Sock->SocketTuple.RemoteEndpoint.Address))

--- a/Source/Gui/Windows/DetailsWindow.hpp
+++ b/Source/Gui/Windows/DetailsWindow.hpp
@@ -37,4 +37,6 @@ public:
 	void Draw();
 
 	void HandleLookupResult(WBuffer const& Buffer);
+
+	std::shared_ptr<WTrafficTree> const& GetTrafficTree() const { return Tree; }
 };

--- a/Source/Gui/Windows/MainWindow.cpp
+++ b/Source/Gui/Windows/MainWindow.cpp
@@ -105,6 +105,11 @@ WMainWindow& WMainWindow::Get()
 	return *WSdlWindow::GetInstance().GetMainWindow();
 }
 
+std::shared_ptr<WTrafficTree> const& WMainWindow::GetTrafficTree()
+{
+	return WSdlWindow::GetInstance().GetMainWindow()->GetDetailsWindow().GetTrafficTree();
+}
+
 void WMainWindow::Draw()
 {
 	ImGuiIO& Io = ImGui::GetIO();

--- a/Source/Gui/Windows/MainWindow.hpp
+++ b/Source/Gui/Windows/MainWindow.hpp
@@ -38,7 +38,7 @@ public:
 	void                Draw();
 
 	WNetworkGraphWindow&      GetNetworkGraphWindow() { return NetworkGraphWindow; }
-	WDetailsWindow&           GetDailyDetailsWindow() { return DetailsWindow; }
+	WDetailsWindow&           GetDetailsWindow() { return DetailsWindow; }
 	WConnectionHistoryWindow& GetConnectionHistoryWindow() { return ConnectionHistoryWindow; }
 	WMemoryUsageWindow&       GetMemoryUsageWindow() { return MemoryUsageWindow; }
 

--- a/Source/Gui/Windows/MainWindow.hpp
+++ b/Source/Gui/Windows/MainWindow.hpp
@@ -35,6 +35,7 @@ class WMainWindow
 
 public:
 	static WMainWindow& Get();
+	static std::shared_ptr<WTrafficTree> const& GetTrafficTree();
 	void                Draw();
 
 	WNetworkGraphWindow&      GetNetworkGraphWindow() { return NetworkGraphWindow; }

--- a/Source/Gui/Windows/TrafficTree.cpp
+++ b/Source/Gui/Windows/TrafficTree.cpp
@@ -783,3 +783,37 @@ std::string const& WTrafficTree::ResolveAddress(WIPAddress const& Address)
 	WClient::GetInstance().SendMessage(MT_ResolveRequest, Request);
 	return Empty;
 }
+
+std::shared_ptr<WApplicationItem> WTrafficTree::FindDaemonItem()
+{
+	std::scoped_lock Lock(DataMutex);
+	for (auto const& TrafficItem : TrafficItems | std::views::values)
+	{
+		if (TrafficItem->GetType() == TI_Application)
+		{
+			auto const& App = std::static_pointer_cast<WApplicationItem>(TrafficItem);
+			if (App->ApplicationName == "waechterd")
+			{
+				return App;
+			}
+		}
+	}
+	return {};
+}
+
+std::shared_ptr<WApplicationItem> WTrafficTree::FindClientItem()
+{
+	std::scoped_lock Lock(DataMutex);
+	for (auto const& TrafficItem : TrafficItems | std::views::values)
+	{
+		if (TrafficItem->GetType() == TI_Application)
+		{
+			auto const& App = std::static_pointer_cast<WApplicationItem>(TrafficItem);
+			if (App->ApplicationName == "waechter")
+			{
+				return App;
+			}
+		}
+	}
+	return {};
+}

--- a/Source/Gui/Windows/TrafficTree.cpp
+++ b/Source/Gui/Windows/TrafficTree.cpp
@@ -210,10 +210,13 @@ bool WTrafficTree::RenderItem(WRenderItemArgs const& Args)
 		ImGui::PopStyleColor();
 	}
 
-	ImGui::TableSetColumnIndex(3);
-	ImGui::PushID(static_cast<int>(Args.Item->ItemId));
-	RuleWidget.Draw(Args, bRowSelected);
-	ImGui::PopID();
+	if (Args.Item->GetType() != TI_Filter)
+	{
+		ImGui::TableSetColumnIndex(3);
+		ImGui::PushID(static_cast<int>(Args.Item->ItemId));
+		RuleWidget.Draw(Args, bRowSelected);
+		ImGui::PopID();
+	}
 
 	return bNodeOpen;
 }

--- a/Source/Gui/Windows/TrafficTree.hpp
+++ b/Source/Gui/Windows/TrafficTree.hpp
@@ -56,7 +56,7 @@ class WTrafficTree
 
 	bool RenderItem(WRenderItemArgs const& Args);
 
-	std::mutex DataMutex;
+	std::recursive_mutex DataMutex;
 
 	void SortTree(ImGuiTableSortSpecs const* Specs);
 
@@ -73,7 +73,7 @@ public:
 	std::string const& ResolveAddress(WIPAddress const& Address);
 
 	template <class T>
-	std::shared_ptr<T> GetSeletedTrafficItem()
+	std::shared_ptr<T> GetSelectedTrafficItem()
 	{
 		if (auto const Ptr = SelectedItem.lock())
 		{
@@ -95,6 +95,9 @@ public:
 		}
 		return {};
 	}
+
+	std::shared_ptr<WApplicationItem> FindDaemonItem();
+	std::shared_ptr<WApplicationItem> FindClientItem();
 
 	void Clear()
 	{

--- a/Source/Util/Data/Rule.hpp
+++ b/Source/Util/Data/Rule.hpp
@@ -16,6 +16,7 @@ enum class ERuleType : uint8_t
 
 struct WTrafficItemRules : WTrafficItemRulesBase
 {
+	WTrafficItemRules() : WTrafficItemRulesBase() {}
 	WBytesPerSecond UploadLimit{ 0 };
 	WBytesPerSecond DownloadLimit{ 0 };
 
@@ -29,7 +30,7 @@ struct WTrafficItemRules : WTrafficItemRulesBase
 
 	[[nodiscard]] WTrafficItemRulesBase AsBase() const
 	{
-		WTrafficItemRulesBase Base;
+		WTrafficItemRulesBase Base{};
 		Base.UploadSwitch = UploadSwitch;
 		Base.DownloadSwitch = DownloadSwitch;
 		Base.UploadMark = UploadMark;
@@ -38,7 +39,7 @@ struct WTrafficItemRules : WTrafficItemRulesBase
 		return Base;
 	}
 
-	std::string ToString() const
+	[[nodiscard]] std::string ToString() const
 	{
 		return std::format(
 			"UploadSwitch={}, DownloadSwitch={}, UploadLimit={}, DownloadLimit={}, UploadMark={}, DownloadMark={}",
@@ -46,8 +47,9 @@ struct WTrafficItemRules : WTrafficItemRulesBase
 			DownloadMark);
 	}
 
-	bool IsDefault() const
+	[[nodiscard]] bool IsDefault() const
 	{
-		return UploadSwitch == SS_None && DownloadSwitch == SS_None && UploadMark == 0 && DownloadMark == 0;
+		return UploadSwitch == SS_None && DownloadSwitch == SS_None && UploadMark == 0 && DownloadMark == 0
+			&& UploadLimit == 0 && DownloadLimit == 0;
 	}
 };

--- a/Source/Util/IPLinkMsg.hpp
+++ b/Source/Util/IPLinkMsg.hpp
@@ -23,11 +23,12 @@ struct WRemoveHtbClassMsg
 	std::string InterfaceName{};
 	uint32_t    Mark{};
 	uint16_t    MinorId{};
+	bool        bIsRoot{};
 
 	template <class Archive>
 	void serialize(Archive& Ar)
 	{
-		Ar(Mark, MinorId, InterfaceName);
+		Ar(Mark, MinorId, InterfaceName, bIsRoot);
 	}
 };
 
@@ -36,12 +37,13 @@ struct WSetupHtbClassMsg
 	std::string     InterfaceName{};
 	uint32_t        Mark{};
 	uint16_t        MinorId{};
+	bool            bIsRoot{};
 	WBytesPerSecond RateLimit{};
 
 	template <class Archive>
 	void serialize(Archive& Ar)
 	{
-		Ar(Mark, MinorId, RateLimit, InterfaceName);
+		Ar(Mark, MinorId, RateLimit, InterfaceName, bIsRoot);
 	}
 };
 


### PR DESCRIPTION
- [x] System blocking
- [x] System limiting
- [x] Add warning when blocking system traffic when connected via websocket
- [x] Add warning when blocking daemon or client when connected via websocket
- [x] Add a root block item to ebpf
- [x] Test system limits without VPN

Both blocking and limiting is implemented, however the system rate limits seem to behave a bit weirdly. A limit of 1MiB results in the bandwidth fluctuating between 300 to 700KiB but never going near the limit and the actual bandwidth consumed by the actual download process is way lower. A VPN probably makes this difficult as it doubles the traffic. 

Also system wide blocking should be done via one single switch in ebpf instead of propagating it down to each item. This way absolutely all traffic is blocked and we don't have to rely on the socket being mapped.

Closes #147 